### PR TITLE
Fixed instructions in readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,7 +3,6 @@
 == Installation
 
 1. Add `gem "spree_product_assembly"` to your Gemfile
-1. Add `gem "jrails"` to your Gemfile
 1. Run `bundle install`
-1. Run `rails g spree_static_content:install`
+1. Run `rails g spree_product_assembly:install`
 1. Run `rake db:migrate`


### PR DESCRIPTION
removed reference to jrails, not needed

now refers to correct install generator.
