### PR TITLE
Fixes mass assignment issues

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,5 +1,5 @@
 Spree::Product.class_eval do
-
+  
   has_and_belongs_to_many  :assemblies, :class_name => "Spree::Product",
         :join_table => "spree_assemblies_parts",
         :foreign_key => "part_id", :association_foreign_key => "assembly_id"
@@ -14,6 +14,8 @@ Spree::Product.class_eval do
   scope :active, lambda { |*args|
     not_deleted.individual_saled.available(args.first)
   }
+
+  attr_accessible :can_be_part, :individual_sale
 
   # returns the number of inventory units "on_hand" for this product
   def on_hand_with_assembly(reload = false)


### PR DESCRIPTION
Just added the necessary attr_acessible to the Product Decorator for mass assignment issues with spree 1.1 and rails 3.2.3
