### PR TITLE
fixes jquery disable in admin/products

### DIFF
--- a/app/views/spree/admin/products/_product_assembly_fields.html.erb
+++ b/app/views/spree/admin/products/_product_assembly_fields.html.erb
@@ -11,7 +11,7 @@
   <% content_for :head do %>
     <script type="text/javascript">
       jQuery(document).ready(function(){
-        $("input[id='product_on_hand']").disable().parent().hide();
+        $("input[id='product_on_hand']").attr('disabled',true).parent().hide();
       });
     </script>
   <% end %>


### PR DESCRIPTION
In the admin/products edit area, the javascript was failing due to an erroneous call to disable().  I converted it to a correct call.
