### PR TITLE
Fixing Spree::Product.active to reflect the change in parameters in spree core

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -12,7 +12,7 @@ Spree::Product.class_eval do
   scope :individual_saled, where(["spree_products.individual_sale = ?", true])
 
   scope :active, lambda { |*args|
-    not_deleted.individual_saled.available(args.first)
+    not_deleted.individual_saled.available(nil, args.first)
   }
 
   attr_accessible :can_be_part, :individual_sale

--- a/spec/unit/product_spec.rb
+++ b/spec/unit/product_spec.rb
@@ -94,6 +94,41 @@ describe Spree::Product do
     end
   end
 
+  describe "Spree::Product.active" do
+    before(:each) do
+      Spree::Product.delete_all
+      @not_available = FactoryGirl.create(:product, :available_on => Time.now + 15.minutes)
+      @future_product = Factory.create(:product, :available_on => Time.now + 2.weeks)
+    end
+
+    it "includes available, individually saled, non deleted product with a price in the correct currency" do
+      product = FactoryGirl.create(:product, :available_on => Time.now - 15.minutes)
+      FactoryGirl.create(:price, variant: product.master)
+      Spree::Product.active('USD').should include(product)
+    end
+
+    it "excludes future products" do
+      product = FactoryGirl.create(:product, :available_on => Time.now + 15.minutes)
+      Spree::Product.active.should_not include(product)
+    end
+
+    it "excludes deleted products" do
+      product = FactoryGirl.create(:product, :deleted_at => Time.now - 15.minutes)
+      Spree::Product.active.should_not include(product)
+    end
+
+    it "excludes products which are only available as a part" do
+      product = FactoryGirl.create(:product, :individual_sale => false)
+      Spree::Product.active.should_not include(product)
+    end
+
+    it "excludes products which do not have a price in the correct currency" do
+      product = FactoryGirl.create(:product, :individual_sale => false)
+      FactoryGirl.create(:price, variant: product.master)
+      Spree::Product.active('GBP').should_not include(product)
+    end
+  end
+
   describe "instance" do
     before(:each) { @product = Factory(:product, :price => 19.99) }
     


### PR DESCRIPTION
Hi, i noticed an error when viewing a product. It's being caused by the currency being passed in to the Spree::Product.active scope when you arent logged in as an admin. This is because the parameters for the scope Spree::Product.available have change in core, so I have reflected this change here. Sorry if the tests are a little overkill, I retrospectively added a spec for each of the major possibilities of the active scope to make sure I everything still worked as expected.
