### PR TITLE
Add failing spec for orders in backend that have both an assembly and a product that is a constituent of that assembly

### DIFF
--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -37,15 +37,36 @@ describe "Checkout" do
   end
 
   context "backend order shipments UI", js: true do
-    include_context "purchases product with part included"
 
-    it "views parts bundled as well" do
-      visit spree.admin_orders_path
-      click_on Spree::Order.last.number
+    context "ordering only the product assembly" do
+      include_context "purchases product with part included"
 
-      page.should have_content(variant.product.name)
+      it "views parts bundled as well" do
+        visit spree.admin_orders_path
+        click_on Spree::Order.last.number
+
+        page.should have_content(variant.product.name)
+      end
     end
+
+    context "ordering assembly and the part as individual sale" do
+      before do
+        visit spree.root_path
+        click_link variant.product.name
+        click_button "add-to-cart-button"
+      end
+      include_context "purchases product with part included"
+
+      it "views parts bundled and not" do
+        visit spree.admin_orders_path
+        click_on Spree::Order.last.number
+
+        page.should have_content(variant.product.name)
+      end
+    end
+
   end
+
 
   def fill_in_address
     address = "order_bill_address_attributes"


### PR DESCRIPTION
This adds a failing spec for orders with both:
- A product assembly
- An item that is a product that also belongs to that assembly

Viewing such orders in the backend causes an sql exception due to the ambiguous semantics of the assemblies_for method in such contexts.

It seems difficult, in the case of a such an order to know whether a given InventoryUnit represents the item that is part of an assembly or just an individual line_item that was sold at the same time... I think the only way to be able to distinguis this unambiguously would be to persist such information at the db level, which would require adding a database migration to add e.g. a line_item_id to inventory unit? I'm not sure what's the best way to proceed here, but would like to discuss it.

Another, related, issue, is whether the extension should allow sourcing the parts of the bundle from multiple stock locations, or whether they should all come from the same stock location. I think we would prefer the latter but perhaps others who use the extension would not.

I think also that generally this extension poses challenges for the new split shipments API and I will try to file a clearly explained issue about it today.

@huoxito @schof
