### PR TITLE
Correct count_on_hand for stock_items representing assemblies:

### DIFF
--- a/app/models/spree/stock_item_decorator.rb
+++ b/app/models/spree/stock_item_decorator.rb
@@ -1,0 +1,9 @@
+Spree::StockItem.class_eval do
+  def count_on_hand
+    variant.product.assembly? ? on_hand_with_assembly : read_attribute(:count_on_hand)
+  end
+
+  def on_hand_with_assembly
+    variant.product.parts.map{|v| stock_location.count_on_hand(v) / variant.product.count_of(v) }.min
+  end
+end

--- a/spec/models/spree/stock_item_spec.rb
+++ b/spec/models/spree/stock_item_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe Spree::StockItem do
+  let(:stock_location) { create(:stock_location) }
+  let(:assembly) { create(:product, name: "Sample Product Assembly") }
+  let(:part1) { create(:product, can_be_part: true) }
+  let(:part2) { create(:product, can_be_part: true) }
+  let(:part1_stock_item) { stock_location.stock_items.where(variant_id: part1.master.id).first }
+  let(:part2_stock_item) { stock_location.stock_items.where(variant_id: part2.master.id).first }
+
+  before do
+    # Add some default stock for the parts
+    part1_stock_item.adjust_count_on_hand(10)
+    part2_stock_item.adjust_count_on_hand(10)
+
+    # Add parts to the assembly
+    assembly.add_part part1.master, 1
+    assembly.add_part part2.master, 3
+  end
+
+  subject {stock_location.stock_items.where(variant_id: assembly.master.id).first }
+
+
+  it "has correct count_on_hand for parts" do
+    part1_stock_item.count_on_hand.should eq(10)
+    part2_stock_item.count_on_hand.should eq(10)
+  end
+
+
+  context "count_on_hand of product assemblies" do
+
+    it "returns the availabiliy for the least available part" do
+      subject.count_on_hand.should eq(3)
+    end
+
+  end
+
+end


### PR DESCRIPTION
The count_on_hand should be a computed value based on the least available part. This was the behaviour of the previous version of the extension and this commit brings that behaviour in line with the new split shipments API (where count_on_hand resides on stock_item).
