### PR TITLE
Add call to sort_packages and method placeholder

### DIFF
--- a/app/models/spree/stock/assembly_prioritizer.rb
+++ b/app/models/spree/stock/assembly_prioritizer.rb
@@ -29,6 +29,7 @@ module Spree
       end
 
       def prioritized_packages
+        sort_packages
         adjust_packages
         prune_packages
         packages
@@ -69,6 +70,10 @@ module Spree
 
         def prune_packages
           packages.reject! { |pkg| pkg.empty? }
+        end
+
+        def sort_packages
+          # override method for custom sorting
         end
     end
   end


### PR DESCRIPTION
Adding `sort_packages` (as in spree core's prioritizer) so developers don't need to override `prioritized_packages` in order to add that call. 

cc @huoxito
