### PR TITLE
Display line_item price in line_item_manifest, not variant price

### DIFF
--- a/app/views/spree/checkout/_line_item_manifest.html.erb
+++ b/app/views/spree/checkout/_line_item_manifest.html.erb
@@ -12,6 +12,6 @@
         <%= item.quantity %>
       <% end %>
     </td>
-    <td class="item-price"><%= display_price(item.variant) %></td>
+    <td class="item-price"><%= item.line_item.single_money %></td>
   </tr>
 <% end %>


### PR DESCRIPTION
In our app there are situations where the price in a specific customers cart will be different from the price on the variant model. In those cases, the line_item_manifest should show same pricing as the orders#edit page. It should pull the display price from the line_item object, not the variant/product object.
