### PR TITLE
Instantiate IU states as empty hash when iterating grouped line_items

### DIFF
--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -41,9 +41,9 @@ module Spree
     def manifest
       items = []
       inventory_units.joins(:variant).includes(:variant, :line_item).group_by(&:variant).each do |variant, units|
-        states = {}
 
         units.group_by(&:line_item).each do |line_item, units|
+          states = {}
           units.group_by(&:state).each { |state, iu| states[state] = iu.count }
           line_item ||= order.find_line_item_by_variant(variant)
 


### PR DESCRIPTION
It seems to instantiating the empty hash in the 'parent' iterator has the effect of assigning the wrong quantities in the state hash when looping over several different product assembly line_items. I'm not 100% sure why, perhaps some not obvious behaviour associated with grouped_by. 

I've attached two screen shots. The first erroneously shows '1 on hand' for the second line of the manifest. There are actually 6 inventory units (all on hand) associated with line of the manifest.
![screenshot 2013-10-22 11 37 57](https://f.cloud.github.com/assets/172627/1382558/ff35b890-3b2f-11e3-99c4-5117925e442c.png)

The second screenshot correctly shows the 6 on-hand inventory units for the second line of the manifest, after moving the instantiation of the states hash within the `units.group_by(&:line_item).each do |line_item, units|` iterator.
![screenshot 2013-10-22 11 29 43](https://f.cloud.github.com/assets/172627/1382559/045eeed6-3b30-11e3-98cf-80addd310bf8.png)
