### PR TITLE
Update order_inventory_assembly.rb

### DIFF
--- a/app/models/spree/order_inventory_assembly.rb
+++ b/app/models/spree/order_inventory_assembly.rb
@@ -17,7 +17,7 @@ module Spree
       if inventory_units.size < (parts_total * line_item.quantity)
 
         product.parts.each do |part|
-          quantity = (product.count_of(part) * (line_item.quantity - line_item.changed_attributes['quantity']))
+          quantity = (product.count_of(part) * (line_item.quantity - line_item.changed_attributes['quantity'].to_i))
 
           shipment = determine_target_shipment(part) unless shipment
           add_to_shipment(shipment, part, quantity)


### PR DESCRIPTION
This solves an issue with adding assembly products to a completed order. A new line item is created, so `line_item.changed_attributes['quantity']` returns `nil` and causes a casting error when trying to subtract it from the current quantity. Parsing the value as integer will return `0` and fix the nil issue.
