### PR TITLE
Hooks for customizing parts per LineItem

### DIFF
--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -17,6 +17,22 @@ module Spree
       OrderInventoryAssembly.new(self).verify
       self.destroy
     end
+    
+    # The parts that apply to this particular LineItem. Usually `product#parts`, but
+    # provided as a hook if you want to override and customize the parts for a specific
+    # LineItem.
+    def parts
+      product.parts
+    end
+    
+    # The number of the specified variant that make up this LineItem. By default, calls
+    # `product#count_of`, but provided as a hook if you want to override and customize
+    # the parts available for a specific LineItem. Note that if you only customize whether
+    # a variant is included in the LineItem, and don't customize the quantity of that part
+    # per LineItem, you shouldn't need to override this method.
+    def count_of(variant)
+      product.count_of(variant)
+    end
 
     private
       def update_inventory

--- a/app/models/spree/order_inventory_assembly.rb
+++ b/app/models/spree/order_inventory_assembly.rb
@@ -12,12 +12,12 @@ module Spree
     end
 
     def verify(shipment = nil)
-      parts_total = product.assemblies_parts.to_a.sum(&:count)
+      parts_total = line_item.parts.sum {|v| line_item.count_of(v)}
 
       if inventory_units.size < (parts_total * line_item.quantity)
 
-        product.parts.each do |part|
-          quantity = (product.count_of(part) * (line_item.quantity - line_item.changed_attributes['quantity'].to_i))
+        line_item.parts.each do |part|
+          quantity = (line_item.count_of(part) * (line_item.quantity - line_item.changed_attributes['quantity'].to_i))
 
           shipment = determine_target_shipment(part) unless shipment
           add_to_shipment(shipment, part, quantity)
@@ -34,8 +34,8 @@ module Spree
 
     private
       def remove(shipment = nil)
-        product.parts.each do |part|
-          quantity = (product.count_of(part) * (line_item.changed_attributes['quantity'] - line_item.quantity))
+        line_item.parts.each do |part|
+          quantity = (line_item.count_of(part) * (line_item.changed_attributes['quantity'] - line_item.quantity))
 
           if shipment.present?
             remove_from_shipment(shipment, part, quantity)

--- a/app/models/spree/stock/assembly_prioritizer.rb
+++ b/app/models/spree/stock/assembly_prioritizer.rb
@@ -40,7 +40,7 @@ module Spree
           order.line_items.each do |line_item|
 
             if line_item.product.assembly?
-              line_item.product.parts.each do |part|
+              line_item.parts.each do |part|
                 update_packages_quantity(part, line_item, part_quantity_required(line_item, part))
               end
             else
@@ -50,7 +50,7 @@ module Spree
         end
 
         def part_quantity_required(line_item, part)
-          line_item.product.count_of(part) * line_item.quantity
+          line_item.count_of(part) * line_item.quantity
         end
 
         def update_packages_quantity(variant, line_item, quantity)

--- a/app/models/spree/stock/availability_validator.rb
+++ b/app/models/spree/stock/availability_validator.rb
@@ -1,13 +1,13 @@
 module Spree
   module Stock
-    # Overriden from spree core to make it also check for assembly parts stock
+    # Overridden from spree core to make it also check for assembly parts stock
     class AvailabilityValidator < ActiveModel::Validator
       def validate(line_item)
         product = line_item.product
 
         valid = if product.assembly?
-          product.parts.all? do |part|
-            Stock::Quantifier.new(part.id).can_supply?(product.count_of(part) * line_item.quantity)
+          line_item.parts.all? do |part|
+            Stock::Quantifier.new(part.id).can_supply?(line_item.count_of(part) * line_item.quantity)
           end
         else
           Stock::Quantifier.new(line_item.variant_id).can_supply? line_item.quantity

--- a/app/models/spree/stock/packer_decorator.rb
+++ b/app/models/spree/stock/packer_decorator.rb
@@ -25,18 +25,18 @@ module Spree
         order.line_items.each do |line_item|
           product = line_item.product
           if product.assembly?
-            product.parts.each do |part|
+            line_item.parts.each do |part|
               # Dont force users to upgrade spree core in order to bump product-assembly
               if (!part.respond_to?(:should_track_inventory?) && Config.track_inventory_levels) ||
                 (part.respond_to?(:should_track_inventory?) && part.should_track_inventory?)
 
                 next unless stock_location.stock_item(part)
   
-                on_hand, backordered = stock_location.fill_status(part, line_item.quantity * product.count_of(part))
+                on_hand, backordered = stock_location.fill_status(part, line_item.quantity * line_item.count_of(part))
                 package.add part, on_hand, :on_hand, line_item if on_hand > 0
                 package.add part, backordered, :backordered, line_item if backordered > 0
               else
-                package.add part, line_item.quantity * product.count_of(part), :on_hand, line_item
+                package.add part, line_item.quantity * line_item.count_of(part), :on_hand, line_item
               end
             end
           elsif (!line_item.respond_to?(:should_track_inventory?) && Config.track_inventory_levels) ||

--- a/app/overrides/spree/shared/_order_details/part_description.html.erb.deface
+++ b/app/overrides/spree/shared/_order_details/part_description.html.erb.deface
@@ -1,8 +1,8 @@
 <!-- insert_bottom 'td[data-hook=order_item_description]' -->
 <% if item.product.assembly? %>
   <ul class='assembly_parts'>
-    <% item.product.parts.each do |v| %>
-    <li>(<%= item.product.count_of(v) %>)  <%= link_to v.name, product_path(v.product) %>  (<%= v.sku %>)</li>
+    <% item.parts.each do |v| %>
+    <li>(<%= item.count_of(v) %>)  <%= link_to v.name, product_path(v.product) %>  (<%= v.sku %>)</li>
     <% end %>
   </ul>
 <% end %>

--- a/app/views/spree/checkout/_line_item_manifest.html.erb
+++ b/app/views/spree/checkout/_line_item_manifest.html.erb
@@ -3,7 +3,7 @@
     <td class="item-image"><%= mini_image(item.variant) %></td>
     <td class="item-name">
       <%= item.variant.name %>
-      <%= render 'spree/orders/cart_description', variant: item.variant %>
+      <%= render 'spree/orders/cart_description', variant: item.variant, line_item: item.line_item %>
     </td>
     <td class="item-qty">
       <% if item.line_item.product.assembly? %>

--- a/app/views/spree/orders/_cart_description.html.erb
+++ b/app/views/spree/orders/_cart_description.html.erb
@@ -1,8 +1,8 @@
 <% product = variant.product
   if product.assembly? %>
 <ul class='assembly_parts'>
-  <% product.parts.each do |v| %>
-  <li>(<%= product.count_of(v) %>)  <%= link_to v.name, product_path(v.product) %>  (<%= v.sku %>)</li>
+  <% line_item.parts.each do |v| %>
+  <li>(<%= line_item.count_of(v) %>)  <%= link_to v.name, product_path(v.product) %>  (<%= v.sku %>)</li>
   <% end %>
 </ul>
 <% end %>


### PR DESCRIPTION
Added `LineItem#parts` and `LineItem#count_of` which call the same method on the LineItem's Product.
All line-item-oriented references to `product.parts` and `product.count_of` converted to use the new
LineItem methods. By overriding these new methods, applications can use custom logic to determine
which parts are actually included in a specific LineItem.

This is very helpful for us, as we had a situation where the product has a sequence of parts, and the user could select to start and end anywhere in the sequence. Without the ability to customize the parts for a specific LineItem, we would have had to create > 50 products, each with a slightly different set of parts, with all the maintenance headaches that entails.  Now we just override `LineItem#parts` with a bit of code to adjust the parts list as needed.

All the specs pass. The only problem I foresee with this, is what happens if the overridden logic in `LineItem#parts` changes (or the inputs it relies on change), resulting in changes to its return values over time. I suppose we should really persist the linkage between LineItem and the part Variant, but this is not expected to be an issue in our application (famous last words...). 

In any case, this PR only provides a seamless hook, and what you do with it is your own issue.
