### PR TITLE
Added support of auto recalculation of assemblies price

### DIFF
--- a/app/models/spree/price_decorator.rb
+++ b/app/models/spree/price_decorator.rb
@@ -1,0 +1,12 @@
+Spree::Price.class_eval do
+  after_update :recalc_assemblies_price
+
+  private
+  
+  def recalc_assemblies_price
+    return unless amount_changed?
+    return unless Spree::ProductAssembly::Config[:auto_recalc_assemblies_price]
+
+    variant.assemblies.each(&:recalculate_assembly_price)
+  end
+end

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -18,6 +18,8 @@ Spree::Product.class_eval do
     not_deleted.individual_saled.available(nil, args.first)
   }
 
+
+  after_update :check_auto_assembly_price
   validate :assembly_cannot_be_part, :if => :assembly?
 
   def add_part(variant, count = 1)
@@ -67,4 +69,22 @@ Spree::Product.class_eval do
   def assembly_cannot_be_part
     errors.add(:can_be_part, Spree.t(:assembly_cannot_be_part)) if can_be_part
   end
+
+  def recalculate_assembly_price
+    my_discount = discount || Spree::ProductAssembly::Config[:default_discount_for_auto_recalc] 
+    part_total = parts.includes(:default_price).map do |part|
+      part.default_price.amount * count_of(part)
+    end.sum
+
+    price = master.default_price
+    price_amount = part_total * (1-my_discount/100)
+    price.update_attribute(:amount, price_amount)
+  end
+
+  def check_auto_assembly_price
+    return unless (assembly? and discount_changed?)
+
+    recalculate_assembly_price
+  end
+  
 end

--- a/app/views/spree/admin/products/_product_assembly_fields.html.erb
+++ b/app/views/spree/admin/products/_product_assembly_fields.html.erb
@@ -12,6 +12,13 @@
 </div>
 
 <% if @product.assembly? %>
+  <% if Spree::ProductAssembly::Config[:auto_recalc_assemblies_price] %>
+  <p>
+    <%= f.label :discount, t("discount")%><br />
+    <%= f.text_field(:discount) %>
+  </p>
+  <% end %>
+
   <% content_for :head do %>
     <script type="text/javascript">
       jQuery(document).ready(function(){

--- a/db/migrate/20130810221723_add_discount_to_assemblies.rb
+++ b/db/migrate/20130810221723_add_discount_to_assemblies.rb
@@ -1,0 +1,13 @@
+class AddDiscountToAssemblies < ActiveRecord::Migration
+  def up
+    change_table(:spree_products) do |t|
+      t.column :discount, :decimal, :precision => 4, :scale => 2
+    end 
+  end
+  
+  def down
+    change_table(:spree_products) do |t|
+      t.remove :discount
+    end 
+  end
+end

--- a/lib/spree/product_assembly_configuration.rb
+++ b/lib/spree/product_assembly_configuration.rb
@@ -1,0 +1,6 @@
+module Spree
+  class ProductAssemblyConfiguration < Preferences::Configuration
+    preference :auto_recalc_assemblies_price, :boolean, :default => false
+    preference :default_discount_for_auto_recalc, :decimal, :default => 10.0
+  end
+end

--- a/lib/spree_product_assembly.rb
+++ b/lib/spree_product_assembly.rb
@@ -1,2 +1,7 @@
 require 'spree_core'
 require 'spree_product_assembly/engine'
+
+module Spree
+  module ProductAssembly
+  end
+end

--- a/lib/spree_product_assembly/engine.rb
+++ b/lib/spree_product_assembly/engine.rb
@@ -1,6 +1,10 @@
 module SpreeProductAssembly
   class Engine < Rails::Engine
     engine_name 'spree_product_assembly'
+    
+    initializer "spree.advanced_cart.environment", :before => :load_config_initializers do |app|
+      Spree::ProductAssembly::Config = Spree::ProductAssemblyConfiguration.new
+    end
 
     config.autoload_paths += %W(#{config.root}/lib)
 


### PR DESCRIPTION
In some cases store owner want apply one pricing formula for all assemblies. In such cases it's convenient to set the price of the assemblies automatically, instead of having to manually set the price of each assembly.
This patch is also available for 2-0-stable & 1-2-stable, see corresponding branches in my fork.