### PR TITLE
Cart description: only show SKU if it exists

### DIFF
--- a/app/views/spree/orders/_cart_description.html.erb
+++ b/app/views/spree/orders/_cart_description.html.erb
@@ -2,7 +2,7 @@
   if product.assembly? %>
 <ul class='assembly_parts'>
   <% line_item.parts.each do |v| %>
-  <li>(<%= line_item.count_of(v) %>)  <%= link_to v.name, product_path(v.product) %>  (<%= v.sku %>)</li>
+  <li>(<%= line_item.count_of(v) %>)  <%= link_to v.name, product_path(v.product) %>  <%= v.sku.present? ? '('+v.sku.to_s+')' : '' %></li>
   <% end %>
 </ul>
 <% end %>


### PR DESCRIPTION
Previously it would show just a set of parentheses with nothing inside them, which looks a bit weird if you're not tracking SKUs in Spree. I realize this is easily defaced, so feel free to ignore if you don't want it in spree-product-assembly, but the previous behavior does look a bit strange.