### PR TITLE
Fix total on hand in a product with parts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,14 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'spree', github: 'spree/spree', :branch => 'master'
-
 gem 'pry-rails'
 gem 'pg'
+gem 'spree', branch: '2-2-stable'
+gem 'spree_sample', '~> 2.2'
+gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '2-2-stable'
+gem 'spring'
+gem 'durable_decorator_rails'
+
 
 group :assets do
   gem 'coffee-rails', '~> 4.0.0'

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -74,14 +74,18 @@ Spree::Product.class_eval do
 
   durably_decorate :total_on_hand , mode: 'strict', sha: 'bdc96bf9a2738a7e18fa3e1f431ccb9cda8b83a7' do
     total = original_total_on_hand
+    total += parts_min_total_on_hand
+    total
+  end
 
+  def parts_min_total_on_hand
     min = Float::INFINITY
+
     self.parts.map do |part|
       count = part.total_on_hand / assembly_part(part).count
       min = count if count < min
     end
 
-    total += min if min != Float::INFINITY
-    total
+    min != Float::INFINITY ? min : 0
   end
 end

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -67,4 +67,21 @@ Spree::Product.class_eval do
   def assembly_cannot_be_part
     errors.add(:can_be_part, Spree.t(:assembly_cannot_be_part)) if can_be_part
   end
+
+  def assembly_part(variant)
+    Spree::AssembliesPart.get(self.id, variant.id)
+  end
+
+  durably_decorate :total_on_hand , mode: 'strict', sha: 'bdc96bf9a2738a7e18fa3e1f431ccb9cda8b83a7' do
+    total = original_total_on_hand
+
+    min = Float::INFINITY
+    self.parts.map do |part|
+      count = part.total_on_hand / assembly_part(part).count
+      min = count if count < min
+    end
+
+    total += min if min != Float::INFINITY
+    total
+  end
 end

--- a/app/models/spree/stock/quantifier_decorator.rb
+++ b/app/models/spree/stock/quantifier_decorator.rb
@@ -1,0 +1,13 @@
+module Spree
+  module Stock
+    Quantifier.class_eval do
+      durably_decorate :total_on_hand, mode: 'strict', sha: 'ac5dc69a5cb0a26152c8578849f9481d0e3085ff' do
+        if @variant.is_master?
+          original_total_on_hand + @variant.product.parts_min_total_on_hand
+        else
+          original_total_on_hand
+        end
+      end
+    end
+  end
+end

--- a/spree_product_assembly.gemspec
+++ b/spree_product_assembly.gemspec
@@ -15,10 +15,12 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency('spree_backend', '~> 2.2.0.beta')
+  s.add_dependency('spree', '~> 2.2.0')
 
   s.add_development_dependency 'rspec-rails', '~> 2.14.0'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'factory_girl_rails', '~> 4.2.1'
+  s.add_development_dependency 'spree_auth_devise'
+  s.add_development_dependency 'durable_decorator_rails'
 end


### PR DESCRIPTION
Total on hand in a product with parts include the part's total on hand, it calculates how many products you can sell according of the total on hand of the product's parts.

i.e.

Product (bundle)
Parts:
-- Part1
---- total_on_hand: 10
-- Part2
---- total_on_hand: 5

if for each bundle you need one part from part1 and two parts from part2, the total_on_hand of the bundle must be 2, because with the total_on_hand of the parts you only can sell 2 bundles.