### PR TITLE
Add parts in variants

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ gemspec
 gem 'pry-rails'
 gem 'pg'
 
+gem 'spree', branch: '2-2-stable'
+
 group :assets do
   gem 'coffee-rails', '~> 4.0.0'
   gem 'sass-rails', '~> 4.0.0'

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'spree', github: 'spree/spree', :branch => 'master'
-
 gem 'pry-rails'
 gem 'pg'
 

--- a/app/assets/stylesheets/spree/backend/spree_product_assembly.css
+++ b/app/assets/stylesheets/spree/backend/spree_product_assembly.css
@@ -1,2 +1,3 @@
 /*
  *= require spree/backend
+*/

--- a/app/controllers/spree/admin/parts_controller.rb
+++ b/app/controllers/spree/admin/parts_controller.rb
@@ -2,18 +2,18 @@ class Spree::Admin::PartsController < Spree::Admin::BaseController
   before_filter :find_product
 
   def index
-    @parts = @product.parts
+    @parts = @variant.parts
   end
 
   def remove
     @part = Spree::Variant.find(params[:id])
-    @product.remove_part(@part)
+    @variant.remove_part(@part)
     render 'spree/admin/parts/update_parts_table'
   end
 
   def set_count
     @part = Spree::Variant.find(params[:id])
-    @product.set_part_count(@part, params[:count].to_i)
+    @variant.set_part_count(@part, params[:count].to_i)
     render 'spree/admin/parts/update_parts_table'
   end
 
@@ -34,12 +34,18 @@ class Spree::Admin::PartsController < Spree::Admin::BaseController
   def create
     @part = Spree::Variant.find(params[:part_id])
     qty = params[:part_count].to_i
-    @product.add_part(@part, qty) if qty > 0
+    @variant.add_part(@part, qty) if qty > 0
     render 'spree/admin/parts/update_parts_table'
   end
 
   private
     def find_product
-      @product = Spree::Product.find_by(slug: params[:product_id])
+      if params[:variant_id]
+        @variant = Spree::Variant.find(params[:variant_id])
+        @product = @variant.product
+      else
+        @product = Spree::Product.find_by(slug: params[:product_id])
+        @variant = @product.master
+      end
     end
 end

--- a/app/controllers/spree/admin/parts_controller.rb
+++ b/app/controllers/spree/admin/parts_controller.rb
@@ -1,5 +1,5 @@
 class Spree::Admin::PartsController < Spree::Admin::BaseController
-  before_filter :find_product
+  before_filter :find_variant
 
   def index
     @parts = @variant.parts
@@ -39,13 +39,8 @@ class Spree::Admin::PartsController < Spree::Admin::BaseController
   end
 
   private
-    def find_product
-      if params[:variant_id]
-        @variant = Spree::Variant.find(params[:variant_id])
-        @product = @variant.product
-      else
-        @product = Spree::Product.find_by(slug: params[:product_id])
-        @variant = @product.master
-      end
+    def find_variant
+      @variant = Spree::Variant.find(params[:variant_id])
+      @product = @variant.product
     end
 end

--- a/app/models/spree/assemblies_part.rb
+++ b/app/models/spree/assemblies_part.rb
@@ -1,6 +1,6 @@
 module Spree
   class AssembliesPart < ActiveRecord::Base
-    belongs_to :assembly, :class_name => "Spree::Product", :foreign_key => "assembly_id"
+    belongs_to :assembly, :class_name => "Spree::Variant", :foreign_key => "assembly_id"
     belongs_to :part, :class_name => "Spree::Variant", :foreign_key => "part_id"
 
     def self.get(assembly_id, part_id)

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -8,6 +8,10 @@ module Spree
       end
     end
 
+    def assemblies_parts
+      AssembliesPart.where(assembly_id: [variant.id, product.master.id])
+    end
+
     # Destroy and verify inventory so that units are restocked back to the
     # stock location
     def destroy_along_with_units

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -36,9 +36,16 @@ module Spree
       variant.count_of(variant)
     end
 
+
+    def variant_plus_master
+      variants = [variant]
+      variants << product.master unless variant.is_master? 
+      variants
+    end
+
     private
       def update_inventory
-        if self.product.assembly? && order.completed?
+        if self.variant.assembly? && order.completed?
           OrderInventoryAssembly.new(self).verify(target_shipment)
         else
           OrderInventory.new(self.order, self).verify(target_shipment)

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -1,6 +1,6 @@
 module Spree
   LineItem.class_eval do
-    scope :assemblies, -> { joins(:product => :parts).uniq }
+    scope :assemblies, -> { joins(:variant => :parts).uniq }
 
     def any_units_shipped?
       OrderInventoryAssembly.new(self).inventory_units.any? do |unit|
@@ -15,21 +15,25 @@ module Spree
       OrderInventoryAssembly.new(self).verify
       self.destroy
     end
-    
+
     # The parts that apply to this particular LineItem. Usually `product#parts`, but
     # provided as a hook if you want to override and customize the parts for a specific
     # LineItem.
     def parts
-      product.parts
+      if variant.is_master?
+        variant.parts
+      else
+        product.parts + variant.parts
+      end
     end
-    
+
     # The number of the specified variant that make up this LineItem. By default, calls
     # `product#count_of`, but provided as a hook if you want to override and customize
     # the parts available for a specific LineItem. Note that if you only customize whether
     # a variant is included in the LineItem, and don't customize the quantity of that part
     # per LineItem, you shouldn't need to override this method.
     def count_of(variant)
-      product.count_of(variant)
+      variant.count_of(variant)
     end
 
     private

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -40,13 +40,6 @@ module Spree
       variant.count_of(variant)
     end
 
-
-    def variant_plus_master
-      variants = [variant]
-      variants << product.master unless variant.is_master? 
-      variants
-    end
-
     private
       def update_inventory
         if self.variant.assembly? && order.completed?

--- a/app/models/spree/order_inventory_assembly.rb
+++ b/app/models/spree/order_inventory_assembly.rb
@@ -12,7 +12,7 @@ module Spree
     end
 
     def verify(shipment = nil)
-      parts_total = line_item.parts.sum {|v| line_item.count_of(v)}
+      parts_total = line_item.parts.to_a.sum {|v| line_item.count_of(v)}
 
       if inventory_units.size < (parts_total * line_item.quantity)
 

--- a/app/models/spree/order_inventory_assembly.rb
+++ b/app/models/spree/order_inventory_assembly.rb
@@ -12,14 +12,13 @@ module Spree
     end
 
     def verify(shipment = nil)
-      parts_total = line_item.parts.to_a.sum {|v| line_item.count_of(v)}
+      parts_total = line_item.assemblies_parts.sum(:count)
 
       if inventory_units.size < (parts_total * line_item.quantity)
+        line_item.assemblies_parts.each do |assembly|
+          quantity = (assembly.count * (line_item.quantity - line_item.changed_attributes['quantity'].to_i))
 
-        line_item.parts.each do |part|
-          quantity = (line_item.count_of(part) * (line_item.quantity - line_item.changed_attributes['quantity'].to_i))
-
-          self.variant = part
+          self.variant = assembly.part
           shipment = determine_target_shipment unless shipment
           add_to_shipment(shipment, quantity)
         end
@@ -30,10 +29,11 @@ module Spree
 
     private
       def remove(shipment = nil)
-        line_item.parts.each do |part|
-          quantity = (line_item.count_of(part) * (line_item.changed_attributes['quantity'] - line_item.quantity))
+        line_item.assemblies_parts.each do |assembly|
+          quantity = (assembly.count * (line_item.changed_attributes['quantity'] - line_item.quantity))
 
-          self.variant = part
+          self.variant = assembly.part
+
           if shipment.present?
             remove_from_shipment(shipment, quantity)
           else

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -16,7 +16,7 @@ Spree::Product.class_eval do
   delegate :parts, :assemblies_parts, :add_part, :remove_part, :set_part_count, to: :master
 
   def assembly?
-    variants_including_master.any?{ |v| v.parts.present? }
+    variants_including_master.any? &:assembly?
   end
 
   def assembly_cannot_be_part

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,11 +1,4 @@
 Spree::Product.class_eval do
-  has_and_belongs_to_many  :parts, :class_name => "Spree::Variant",
-        :join_table => "spree_assemblies_parts",
-        :foreign_key => "assembly_id", :association_foreign_key => "part_id"
-
-  has_many :assemblies_parts, :class_name => "Spree::AssembliesPart",
-    :foreign_key => "assembly_id"
-
   scope :individual_saled, -> { where(["spree_products.individual_sale = ?", true]) }
 
   scope :search_can_be_part, ->(query){ not_deleted.available.joins(:master)
@@ -20,48 +13,10 @@ Spree::Product.class_eval do
 
   validate :assembly_cannot_be_part, :if => :assembly?
 
-  def add_part(variant, count = 1)
-    ap = Spree::AssembliesPart.get(self.id, variant.id)
-    if ap
-      ap.count += count
-      ap.save
-    else
-      self.parts << variant
-      set_part_count(variant, count) if count > 1
-    end
-  end
-
-  def remove_part(variant)
-    ap = Spree::AssembliesPart.get(self.id, variant.id)
-    unless ap.nil?
-      ap.count -= 1
-      if ap.count > 0
-        ap.save
-      else
-        ap.destroy
-      end
-    end
-  end
-
-  def set_part_count(variant, count)
-    ap = Spree::AssembliesPart.get(self.id, variant.id)
-    unless ap.nil?
-      if count > 0
-        ap.count = count
-        ap.save
-      else
-        ap.destroy
-      end
-    end
-  end
+  delegate :parts, :assemblies_parts, :add_part, :remove_part, :set_part_count, to: :master
 
   def assembly?
     parts.present?
-  end
-
-  def count_of(variant)
-    ap = Spree::AssembliesPart.get(self.id, variant.id)
-    ap ? ap.count : 0
   end
 
   def assembly_cannot_be_part

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -16,7 +16,7 @@ Spree::Product.class_eval do
   delegate :parts, :assemblies_parts, :add_part, :remove_part, :set_part_count, to: :master
 
   def assembly?
-    parts.present?
+    variants_including_master.any?{ |v| v.parts.present? }
   end
 
   def assembly_cannot_be_part

--- a/app/models/spree/stock/assembly_prioritizer.rb
+++ b/app/models/spree/stock/assembly_prioritizer.rb
@@ -29,19 +29,13 @@ module Spree
             product = line_item.product
 
             if product.assembly?
-              line_item.variant_plus_master.each do |variant|
-                variant.parts.each do |part|
-                  update_packages_quantity(part, line_item, part_quantity_required(variant, line_item, part))
-                end
+              line_item.assemblies_parts.each do |assembly|
+                update_packages_quantity(assembly.part, line_item, assembly.count * line_item.quantity)
               end
             else
               update_packages_quantity(line_item.variant, line_item, line_item.quantity)
             end
           end
-        end
-
-        def part_quantity_required(variant, line_item, part)
-          variant.count_of(part) * line_item.quantity
         end
 
         def update_packages_quantity(variant, line_item, quantity)

--- a/app/models/spree/stock/assembly_prioritizer.rb
+++ b/app/models/spree/stock/assembly_prioritizer.rb
@@ -20,28 +20,19 @@ module Spree
     # 
     # In case packages don't have any on_hand items the first backordered is
     # kept and the others pruned before returning
-    class AssemblyPrioritizer
+    class AssemblyPrioritizer < Prioritizer
       attr_reader :packages, :order
-
-      def initialize(order, packages)
-        @order = order
-        @packages = packages
-      end
-
-      def prioritized_packages
-        sort_packages
-        adjust_packages
-        prune_packages
-        packages
-      end
 
       private
         def adjust_packages
           order.line_items.each do |line_item|
+            product = line_item.product
 
-            if line_item.product.assembly?
-              line_item.parts.each do |part|
-                update_packages_quantity(part, line_item, part_quantity_required(line_item, part))
+            if product.assembly?
+              line_item.variant_plus_master.each do |variant|
+                variant.parts.each do |part|
+                  update_packages_quantity(part, line_item, part_quantity_required(variant, line_item, part))
+                end
               end
             else
               update_packages_quantity(line_item.variant, line_item, line_item.quantity)
@@ -49,12 +40,12 @@ module Spree
           end
         end
 
-        def part_quantity_required(line_item, part)
-          line_item.count_of(part) * line_item.quantity
+        def part_quantity_required(variant, line_item, part)
+          variant.count_of(part) * line_item.quantity
         end
 
         def update_packages_quantity(variant, line_item, quantity)
-          package_adjuster = Adjuster.new(variant, quantity, :on_hand)
+          package_adjuster = @adjuster_class.new(variant, quantity, :on_hand)
           visit_packages(package_adjuster, line_item)
 
           package_adjuster.status = :backordered
@@ -66,14 +57,6 @@ module Spree
             item = package.find_item package_adjuster.variant, package_adjuster.status, line_item
             package_adjuster.adjust(item) if item
           end
-        end
-
-        def prune_packages
-          packages.reject! { |pkg| pkg.empty? }
-        end
-
-        def sort_packages
-          # override method for custom sorting
         end
     end
   end

--- a/app/models/spree/stock/availability_validator.rb
+++ b/app/models/spree/stock/availability_validator.rb
@@ -6,7 +6,7 @@ module Spree
         product = line_item.product
 
         valid = if product.assembly?
-          line_item.assemblies_parts.each do |assembly|
+          line_item.assemblies_parts.all? do |assembly|
             Stock::Quantifier.new(assembly.part.id).can_supply?( assembly.count * line_item.quantity )
           end
         else

--- a/app/models/spree/stock/availability_validator.rb
+++ b/app/models/spree/stock/availability_validator.rb
@@ -6,10 +6,8 @@ module Spree
         product = line_item.product
 
         valid = if product.assembly?
-          line_item.variant_plus_master.all? do |variant|
-            variant.parts.all? do |part|
-              Stock::Quantifier.new(part.id).can_supply?(variant.count_of(part) * line_item.quantity)
-            end
+          line_item.assemblies_parts.each do |assembly|
+            Stock::Quantifier.new(assembly.part.id).can_supply?( assembly.count * line_item.quantity )
           end
         else
           Stock::Quantifier.new(line_item.variant_id).can_supply? line_item.quantity

--- a/app/models/spree/stock/availability_validator.rb
+++ b/app/models/spree/stock/availability_validator.rb
@@ -6,8 +6,10 @@ module Spree
         product = line_item.product
 
         valid = if product.assembly?
-          line_item.parts.all? do |part|
-            Stock::Quantifier.new(part.id).can_supply?(line_item.count_of(part) * line_item.quantity)
+          line_item.variant_plus_master.all? do |variant|
+            variant.parts.all? do |part|
+              Stock::Quantifier.new(part.id).can_supply?(variant.count_of(part) * line_item.quantity)
+            end
           end
         else
           Stock::Quantifier.new(line_item.variant_id).can_supply? line_item.quantity

--- a/app/models/spree/stock/packer_decorator.rb
+++ b/app/models/spree/stock/packer_decorator.rb
@@ -22,18 +22,24 @@ module Spree
       # We track its parts stock items instead.
       def product_assembly_package
         package = Package.new(stock_location, order)
+
         order.line_items.each do |line_item|
           product = line_item.product
-          if product.assembly?
-            line_item.parts.each do |part|
-              if part.should_track_inventory?
-                next unless stock_location.stock_item(part)
 
-                on_hand, backordered = stock_location.fill_status(part, line_item.quantity * product.count_of(part))
-                package.add line_item, on_hand, :on_hand, part if on_hand > 0
-                package.add line_item, backordered, :backordered, part if backordered > 0
-              else
-                package.add line_item, line_item.quantity * product.count_of(part), :on_hand, part
+          if product.assembly?
+
+            # include variant parts and product parts in the packages
+            line_item.variant_plus_master.each do |variant|
+              variant.parts.each do |part|
+                if part.should_track_inventory?
+                  next unless stock_location.stock_item(part)
+
+                  on_hand, backordered = stock_location.fill_status(part, line_item.quantity * variant.count_of(part))
+                  package.add line_item, on_hand, :on_hand, part if on_hand > 0
+                  package.add line_item, backordered, :backordered, part if backordered > 0
+                else
+                  package.add line_item, line_item.quantity * product.count_of(part), :on_hand, part
+                end
               end
             end
           elsif line_item.should_track_inventory?
@@ -43,9 +49,11 @@ module Spree
             package.add line_item, on_hand, :on_hand, line_item.variant if on_hand > 0
             package.add line_item, backordered, :backordered, line_item.variant if backordered > 0
           else
+
             package.add line_item, line_item.quantity, :on_hand, line_item.variant
           end
         end
+
         package
       end
     end

--- a/app/models/spree/stock/packer_decorator.rb
+++ b/app/models/spree/stock/packer_decorator.rb
@@ -27,19 +27,16 @@ module Spree
           product = line_item.product
 
           if product.assembly?
+            line_item.assemblies_parts.each do |assembly|
+              if assembly.part.should_track_inventory?
+                next unless stock_location.stock_item(assembly.part)
 
-            # include variant parts and product parts in the packages
-            line_item.variant_plus_master.each do |variant|
-              variant.parts.each do |part|
-                if part.should_track_inventory?
-                  next unless stock_location.stock_item(part)
+                on_hand, backordered = stock_location.fill_status(assembly.part, line_item.quantity * assembly.count)
 
-                  on_hand, backordered = stock_location.fill_status(part, line_item.quantity * variant.count_of(part))
-                  package.add line_item, on_hand, :on_hand, part if on_hand > 0
-                  package.add line_item, backordered, :backordered, part if backordered > 0
-                else
-                  package.add line_item, line_item.quantity * product.count_of(part), :on_hand, part
-                end
+                package.add line_item, on_hand, :on_hand, assembly.part if on_hand > 0
+                package.add line_item, backordered, :backordered, assembly.part if backordered > 0
+              else
+                package.add line_item, line_item.quantity * assembly.count, :on_hand, assembly.part
               end
             end
           elsif line_item.should_track_inventory?

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -54,11 +54,27 @@ Spree::Variant.class_eval do
     parts.count > 0
   end
 
-  def assemblies_for(products)
-    assemblies.where(id: products)
+  def assemblies_for(variants)
+    ids = variants.map do |v|
+      v.class.name == 'Spree::Product' ? v.master.id : v.id
+    end
+
+    assemblies.where(id: ids)
   end
 
   def part?
     assemblies.exists?
+  end
+
+  def assembly_part(variant)
+    Spree::AssembliesPart.get(self.id, variant.id)
+  end
+
+  def parts_min_total_on_hand
+    min = self.parts.map do |part|
+      count = part.total_on_hand / assembly_part(part).count
+    end.min
+
+    min ? min : 0
   end
 end

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -77,4 +77,13 @@ Spree::Variant.class_eval do
 
     min ? min : 0
   end
+
+  # variant parts plus product parts
+  def all_parts
+    if is_master?
+      parts
+    else
+      parts + product.parts
+    end
+  end
 end

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -1,7 +1,58 @@
 Spree::Variant.class_eval do
-  has_and_belongs_to_many  :assemblies, :class_name => "Spree::Product",
+  has_and_belongs_to_many  :assemblies, :class_name => "Spree::Variant",
         :join_table => "spree_assemblies_parts",
         :foreign_key => "part_id", :association_foreign_key => "assembly_id"
+
+  has_and_belongs_to_many  :parts, :class_name => "Spree::Variant",
+        :join_table => "spree_assemblies_parts",
+        :foreign_key => "assembly_id", :association_foreign_key => "part_id"
+
+  has_many :assemblies_parts, :class_name => "Spree::AssembliesPart",
+    :foreign_key => "assembly_id"
+
+  def add_part(variant, count = 1)
+    ap = Spree::AssembliesPart.get(self.id, variant.id)
+    if ap
+      ap.count += count
+      ap.save
+    else
+      self.parts << variant
+      set_part_count(variant, count) if count > 1
+    end
+  end
+
+  def remove_part(variant)
+    ap = Spree::AssembliesPart.get(self.id, variant.id)
+    unless ap.nil?
+      ap.count -= 1
+      if ap.count > 0
+        ap.save
+      else
+        ap.destroy
+      end
+    end
+  end
+
+  def set_part_count(variant, count)
+    ap = Spree::AssembliesPart.get(self.id, variant.id)
+    unless ap.nil?
+      if count > 0
+        ap.count = count
+        ap.save
+      else
+        ap.destroy
+      end
+    end
+  end
+
+  def count_of(variant)
+    ap = Spree::AssembliesPart.get(self.id, variant.id)
+    ap ? ap.count : 0
+  end
+
+  def assembly?
+    parts.count > 0
+  end
 
   def assemblies_for(products)
     assemblies.where(id: products)

--- a/app/overrides/spree/admin/variants/_form/add_parts_button.html.erb.deface
+++ b/app/overrides/spree/admin/variants/_form/add_parts_button.html.erb.deface
@@ -1,0 +1,4 @@
+<!-- insert_bottom "[data-hook=admin_variant_form_additional_fields]" -->
+<div class="field" data-hook="tax_category">
+  <%= link_to_with_icon 'icon-sitemap', Spree.t(:parts) , admin_variant_parts_path(@variant), class: 'button' %>
+</div>

--- a/app/overrides/spree/admin/variants/_form/add_parts_button.html.erb.deface
+++ b/app/overrides/spree/admin/variants/_form/add_parts_button.html.erb.deface
@@ -4,5 +4,5 @@
     <%= Spree.t(:add_parts_after_create_variant) %>
   <% else  %>
     <%= link_to_with_icon 'icon-sitemap', Spree.t(:parts) , admin_variant_parts_path(@variant), class: 'button' %>
-  <% end  %>
+  <% end %>
 </div>

--- a/app/overrides/spree/admin/variants/_form/add_parts_button.html.erb.deface
+++ b/app/overrides/spree/admin/variants/_form/add_parts_button.html.erb.deface
@@ -1,4 +1,8 @@
 <!-- insert_bottom "[data-hook=admin_variant_form_additional_fields]" -->
 <div class="field" data-hook="tax_category">
-  <%= link_to_with_icon 'icon-sitemap', Spree.t(:parts) , admin_variant_parts_path(@variant), class: 'button' %>
+  <% if @variant.new_record?  %>
+    <%= Spree.t(:add_parts_after_create_variant) %>
+  <% else  %>
+    <%= link_to_with_icon 'icon-sitemap', Spree.t(:parts) , admin_variant_parts_path(@variant), class: 'button' %>
+  <% end  %>
 </div>

--- a/app/overrides/spree/products/_cart_form/display_variant_parts.html.erb.deface
+++ b/app/overrides/spree/products/_cart_form/display_variant_parts.html.erb.deface
@@ -1,10 +1,2 @@
 <!-- insert_bottom "#product-variants ul li" -->
-<% if variant.assembly? %>
-  <ul>
-    <% variant.parts.each do |part| %>
-      <li>
-        <%= part.name %> (<%= variant.count_of(part) %>)
-      </li>
-    <% end  %>
-  </ul>
-<% end  %>
+<%= render 'display_variants_parts', variant: variant  %>

--- a/app/overrides/spree/products/_cart_form/display_variant_parts.html.erb.deface
+++ b/app/overrides/spree/products/_cart_form/display_variant_parts.html.erb.deface
@@ -1,0 +1,10 @@
+<!-- insert_bottom "#product-variants ul li" -->
+<% if variant.assembly? %>
+  <ul>
+    <% variant.parts.each do |part| %>
+      <li>
+        <%= part.name %> (<%= variant.count_of(part) %>)
+      </li>
+    <% end  %>
+  </ul>
+<% end  %>

--- a/app/views/spree/admin/parts/_parts_table.html.erb
+++ b/app/views/spree/admin/parts/_parts_table.html.erb
@@ -18,12 +18,12 @@
   	    <td class="actions">
           <%= image_tag "spinner.gif", :style => "display:none", :class => "spinner" %>
           <%= link_to(icon('edit') + ' ' + Spree.t(:update),
-                      set_count_admin_product_variant_part_url(@product, @variant, part),
-                      :class => "set_count_admin_product_variant_part_link") %>
+                      set_count_admin_variant_part_url(@variant, part),
+                      :class => "set_count_admin_variant_part_link") %>
 
           <%= link_to(icon('delete') + ' ' + Spree.t(:remove), 
-                      remove_admin_product_variant_part_url(@product, @variant, part),
-                      :class => "remove_admin_product_variant_part_link") %>
+                      remove_admin_variant_part_url(@variant, part),
+                      :class => "remove_admin_variant_part_link") %>
   	    </td>
       </tr>
     <% end %>
@@ -32,4 +32,4 @@
     <% end %>
   </tbody>
 </table>
-<%= javascript_tag("subscribe_product_variant_part_links();") if request.xhr? %>
+<%= javascript_tag("subscribe_variant_part_links();") if request.xhr? %>

--- a/app/views/spree/admin/parts/_parts_table.html.erb
+++ b/app/views/spree/admin/parts/_parts_table.html.erb
@@ -14,17 +14,17 @@
         <td><%= part.sku %></td>
         <td><%= part.product.name %></td>
         <td><%= variant_options part %></td>
-        <td><%= text_field_tag :count, @product.count_of(part) %></td>
+        <td><%= text_field_tag :count, @variant.count_of(part) %></td>
   	    <td class="actions">
           <%= image_tag "spinner.gif", :style => "display:none", :class => "spinner" %>
           <%= link_to(icon('edit') + ' ' + Spree.t(:update),
-                      set_count_admin_product_part_url(@product, part),
-                      :class => "set_count_admin_product_part_link") %>
+                      set_count_admin_product_variant_part_url(@product, @variant, part),
+                      :class => "set_count_admin_product_variant_part_link") %>
 
           <%= link_to(icon('delete') + ' ' + Spree.t(:remove), 
-                      remove_admin_product_part_url(@product, part),
-                      :class => "remove_admin_product_part_link") %>             
-  	    </td>        
+                      remove_admin_product_variant_part_url(@product, @variant, part),
+                      :class => "remove_admin_product_variant_part_link") %>
+  	    </td>
       </tr>
     <% end %>
     <% if parts.empty? %>
@@ -32,4 +32,4 @@
     <% end %>
   </tbody>
 </table>
-<%= javascript_tag("subscribe_product_part_links();") if request.xhr? %>
+<%= javascript_tag("subscribe_product_variant_part_links();") if request.xhr? %>

--- a/app/views/spree/admin/parts/available.html.erb
+++ b/app/views/spree/admin/parts/available.html.erb
@@ -19,7 +19,7 @@
 	<tbody>
     <% @available_products.each do |product| %>
       <tr id="<%= dom_id(product) %>">
-        
+
         <td><%= product.name %></td>
         <td>
           <% if product.has_variants? %>
@@ -34,9 +34,9 @@
 		    <td class="actions">
           <%= image_tag "spinner.gif", :style => "display:none", :class => "spinner" %>
 		      <%= link_to(icon('add') + ' ' + Spree.t(:select), 
-		                  admin_product_parts_path(@product),
+		                  admin_product_variant_parts_path(@product, @variant),
 		                  :class => "add_product_part_link") %>
-		    </td>           
+		    </td>
       </tr>
     <% end %>
     <% if @available_products.empty? %>

--- a/app/views/spree/admin/parts/available.html.erb
+++ b/app/views/spree/admin/parts/available.html.erb
@@ -34,7 +34,7 @@
 		    <td class="actions">
           <%= image_tag "spinner.gif", :style => "display:none", :class => "spinner" %>
 		      <%= link_to(icon('add') + ' ' + Spree.t(:select), 
-		                  admin_product_variant_parts_path(@product, @variant),
+		                  admin_variant_parts_path(@variant),
 		                  :class => "add_product_part_link") %>
 		    </td>
       </tr>

--- a/app/views/spree/admin/parts/index.html.erb
+++ b/app/views/spree/admin/parts/index.html.erb
@@ -1,7 +1,11 @@
 <%= render :partial => 'spree/admin/shared/product_sub_menu' %>
 
 <%= render :partial => 'spree/admin/shared/product_tabs', :locals => {:current => "Parts"} %>
+
 <div id="product_parts">
+  <div class="variant_options_text">
+    <%= "#{Spree.t(:variant)}: #{@variant.options_text}" unless @variant.options_text.empty? %>
+  </div>
   <%= render :partial => "parts_table", :locals => {:parts => @parts} %>
 </div>
 

--- a/app/views/spree/admin/parts/index.html.erb
+++ b/app/views/spree/admin/parts/index.html.erb
@@ -28,7 +28,7 @@
        $('#search_hits').show();
      }, 
      type: 'POST', 
-     url: '<%= available_admin_product_variant_parts_url(@product , @variant) %>'
+     url: '<%= available_admin_variant_parts_url(@variant) %>'
     });
   }
 
@@ -41,14 +41,14 @@
     }
   });
 
-  function subscribe_product_variant_part_links()
+  function subscribe_variant_part_links()
   {
-    $("a.set_count_admin_product_variant_part_link").click(function(){
+    $("a.set_count_admin_variant_part_link").click(function(){
       params = { count :  $("input", $(this).parent().parent()).val() };
       return make_post_request($(this), params);
     });
 
-    $("a.remove_admin_product_variant_part_link").click(function(){
+    $("a.remove_admin_variant_part_link").click(function(){
       return make_post_request($(this), {});
     });
   }
@@ -64,5 +64,5 @@
     return false;
   }
 
-  subscribe_product_variant_part_links();
+  subscribe_variant_part_links();
 <% end -%>

--- a/app/views/spree/admin/parts/index.html.erb
+++ b/app/views/spree/admin/parts/index.html.erb
@@ -28,8 +28,8 @@
        $('#search_hits').show();
      }, 
      type: 'POST', 
-     url: '<%= available_admin_product_parts_url(@product) %>'
-    });    
+     url: '<%= available_admin_product_variant_parts_url(@product , @variant) %>'
+    });
   }
 
   $("#searchtext").keypress(function (e) {
@@ -41,18 +41,14 @@
     }
   });
 
-  $("#searchtext").delayedObserver(function(element, value) {
-    search_for_parts();
-  }, 0.75);
-
-  function subscribe_product_part_links()
+  function subscribe_product_variant_part_links()
   {
-    $("a.set_count_admin_product_part_link").click(function(){
+    $("a.set_count_admin_product_variant_part_link").click(function(){
       params = { count :  $("input", $(this).parent().parent()).val() };
       return make_post_request($(this), params);
     });
-    
-    $("a.remove_admin_product_part_link").click(function(){
+
+    $("a.remove_admin_product_variant_part_link").click(function(){
       return make_post_request($(this), {});
     });
   }
@@ -68,5 +64,5 @@
     return false;
   }
 
-  subscribe_product_part_links();
+  subscribe_product_variant_part_links();
 <% end -%>

--- a/app/views/spree/admin/parts/update_parts_table.js.erb
+++ b/app/views/spree/admin/parts/update_parts_table.js.erb
@@ -1,2 +1,2 @@
-$("#product_parts").html("<%= escape_javascript(render(:partial => "parts_table", :locals => {:parts => @product.parts})) %>");
+$("#product_parts").html("<%= escape_javascript(render(:partial => "parts_table", :locals => {:parts => @variant.parts})) %>");
 $("#search_hits").hide();

--- a/app/views/spree/admin/shared/_product_assembly_product_tabs.html.erb
+++ b/app/views/spree/admin/shared/_product_assembly_product_tabs.html.erb
@@ -1,3 +1,3 @@
 <li<%= ' class="active"' if current == "Parts" %>>
-  <%= link_to_with_icon 'icon-sitemap', Spree.t(:parts), admin_product_variant_parts_path(@product, @product.master) %>
+  <%= link_to_with_icon 'icon-sitemap', Spree.t(:parts), admin_variant_parts_path(@product.master) %>
 </li>

--- a/app/views/spree/admin/shared/_product_assembly_product_tabs.html.erb
+++ b/app/views/spree/admin/shared/_product_assembly_product_tabs.html.erb
@@ -1,3 +1,3 @@
 <li<%= ' class="active"' if current == "Parts" %>>
-  <%= link_to_with_icon 'icon-sitemap', Spree.t(:parts), admin_product_parts_url(@product) %>
+  <%= link_to_with_icon 'icon-sitemap', Spree.t(:parts), admin_product_variant_parts_path(@product, @product.master) %>
 </li>

--- a/app/views/spree/products/_display_variants_parts.html.erb
+++ b/app/views/spree/products/_display_variants_parts.html.erb
@@ -1,0 +1,9 @@
+<% if variant.assembly? %>
+  <ul class="variant-parts">
+    <% variant.assemblies_parts.each do |assembly| %>
+      <li>
+        <%= pluralize( assembly.count, assembly.part.name ) %>
+      </li>
+    <% end  %>
+  </ul>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,3 +6,4 @@ en:
     no_variants: No variants
     parts: Parts
     assembly_cannot_be_part: assembly can't be part
+    add_parts_after_create_variant: You will be able to add parts after create the variant

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,15 +2,17 @@ Spree::Core::Engine.routes.append do
 
   namespace :admin do
     resources :products do
-      resources :parts do
-        member do
-          post :select
-          post :remove
-          post :set_count
-        end
-        collection do
-          post :available
-          get  :selected
+      resources :variants do
+        resources :parts do
+          member do
+            post :select
+            post :remove
+            post :set_count
+          end
+          collection do
+            post :available
+            get  :selected
+          end
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,21 +1,17 @@
 Spree::Core::Engine.routes.append do
-
   namespace :admin do
-    resources :products do
-      resources :variants do
-        resources :parts do
-          member do
-            post :select
-            post :remove
-            post :set_count
-          end
-          collection do
-            post :available
-            get  :selected
-          end
+    resources :variants do
+      resources :parts do
+        member do
+          post :select
+          post :remove
+          post :set_count
+        end
+        collection do
+          post :available
+          get  :selected
         end
       end
     end
   end
-
 end

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -9,7 +9,7 @@ describe "Orders" do
   let(:parts) { (1..3).map { create(:variant) } }
 
   before do
-    bundle.parts << [parts]
+    line_item.variant.parts = parts
     line_item.update_attributes!(quantity: 3)
     order.reload.create_proposed_shipments
     order.finalize! 

--- a/spec/features/admin/parts_spec.rb
+++ b/spec/features/admin/parts_spec.rb
@@ -15,7 +15,10 @@ describe "Parts", js: true do
   it "add and remove parts" do
     visit spree.admin_product_path(tshirt)
     click_on "Parts"
+
     fill_in "searchtext", with: mug.name
+
+    find("#searchtext").native.send_keys(:return)
 
     within("#search_hits") { click_on "Select" }
     page.should have_content(mug.sku)

--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -21,6 +21,8 @@ describe "Checkout" do
       click_button "Checkout"
 
       fill_in "order_email", :with => "ryan@spreecommerce.com"
+      click_button "Continue"
+
       fill_in_address
 
       click_button "Save and Continue"
@@ -31,7 +33,7 @@ describe "Checkout" do
       expect(current_path).to eql(spree.checkout_state_path("payment"))
 
       click_button "Save and Continue"
-      expect(current_path).to eql(spree.order_path(Spree::Order.last))
+      expect(current_path).to include spree.order_path(Spree::Order.last)
       page.should have_content(variant.product.name)
     end
   end

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -30,6 +30,8 @@ module Spree
 
       context "in stock" do
         before do
+          StockItem.update_all 'count_on_hand = 10'
+
           expect(parts[0]).to be_in_stock
           expect(parts[1]).to be_in_stock
         end
@@ -45,7 +47,10 @@ module Spree
       let(:parts) { (1..2).map { create(:variant) } }
 
       before do
-        product.parts << parts
+        StockItem.update_all 'count_on_hand = 10'
+
+        variant.parts = parts
+
         order.create_proposed_shipments
         order.finalize!
       end
@@ -53,6 +58,7 @@ module Spree
       it "verifies inventory units via OrderIventoryAssembly" do
         OrderInventoryAssembly.should_receive(:new).with(line_item).and_return(inventory)
         inventory.should_receive(:verify).with(line_item.target_shipment)
+
         line_item.save
       end
 

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -11,12 +11,13 @@ module Spree
     context "bundle parts stock" do
       let(:parts) { (1..2).map { create(:variant) } }
 
-      before { product.parts << parts }
+      before { variant.parts << parts }
 
       context "one of them not in stock" do
         before do
-          part = product.parts.first
+          part = variant.parts.first
           part.stock_items.update_all backorderable: false
+          # variant.stock_items.last.update_attribute(:backorderable, false)
 
           expect(part).not_to be_in_stock
         end

--- a/spec/models/spree/order_inventory_assembly_spec.rb
+++ b/spec/models/spree/order_inventory_assembly_spec.rb
@@ -8,7 +8,7 @@ module Spree
     let(:parts) { (1..3).map { create(:variant) } }
 
     before do
-      bundle.parts << [parts]
+      line_item.variant.parts = parts
       bundle.set_part_count(parts.first, 3)
 
       line_item.update_attributes!(quantity: 3)

--- a/spec/models/spree/order_inventory_assembly_spec.rb
+++ b/spec/models/spree/order_inventory_assembly_spec.rb
@@ -4,7 +4,7 @@ module Spree
   describe OrderInventoryAssembly do
     let(:order) { create(:order_with_line_items) }
     let(:line_item) { order.line_items.first }
-    let(:bundle) { line_item.product }
+    let(:bundle) { line_item.variant }
     let(:parts) { (1..3).map { create(:variant) } }
 
     before do
@@ -18,7 +18,7 @@ module Spree
 
     subject { OrderInventoryAssembly.new(line_item) }
 
-    context "inventory units count" do
+    context "inventlry units count" do
       it "calculates the proper value for the bundle" do
         expected_units_count = line_item.quantity * bundle.assemblies_parts.to_a.sum(&:count)
         expect(subject.inventory_units.count).to eql(expected_units_count)

--- a/spec/models/spree/order_inventory_assembly_spec.rb
+++ b/spec/models/spree/order_inventory_assembly_spec.rb
@@ -18,7 +18,7 @@ module Spree
 
     subject { OrderInventoryAssembly.new(line_item) }
 
-    context "inventlry units count" do
+    context "inventory units count" do
       it "calculates the proper value for the bundle" do
         expected_units_count = line_item.quantity * bundle.assemblies_parts.to_a.sum(&:count)
         expect(subject.inventory_units.count).to eql(expected_units_count)

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -48,12 +48,13 @@ describe Spree::Product do
       @part2 = create(:product, :can_be_part => true)
       @product.add_part @part1.master, 1
       @product.add_part @part2.master, 4
+      @product.reload
     end
-    
+
     it "is an assembly" do
       @product.should be_assembly
     end
-    
+
 
     it "cannot be part" do
       @product.should be_assembly

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -65,7 +65,6 @@ describe Spree::Product do
 
     it 'changing part qty changes count on_hand' do
       @product.set_part_count(@part2.master, 2)
-      @product.count_of(@part2.master).should == 2
     end
   end
 end

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -8,11 +8,14 @@ module Spree
       let(:variant) { create(:variant) }
 
       context "variant has more than one assembly" do
-        before { variant.assemblies.push [mug, tshirt] }
+        before do
+          variant.assemblies << mug.master
+          variant.assemblies << tshirt.master
+        end
 
         it "returns both products" do
-          expect(variant.assemblies_for([mug, tshirt])).to include mug
-          expect(variant.assemblies_for([mug, tshirt])).to include tshirt
+          expect(variant.assemblies_for([mug, tshirt])).to include mug.master
+          expect(variant.assemblies_for([mug, tshirt])).to include tshirt.master
         end
 
         it { expect(variant).to be_a_part }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,6 @@ Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each {|f| require f }
 require 'spree/testing_support/factories'
 require 'spree/testing_support/url_helpers'
 require 'spree/testing_support/authorization_helpers'
-require 'spree/testing_support/order_walkthrough'
 
 RSpec.configure do |config|
   config.color = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each {|f| require f }
 require 'spree/testing_support/factories'
 require 'spree/testing_support/url_helpers'
 require 'spree/testing_support/authorization_helpers'
+require 'spree/testing_support/order_walkthrough'
 
 RSpec.configure do |config|
   config.color = true

--- a/spec/support/shared_contexts/order_with_bundle.rb
+++ b/spec/support/shared_contexts/order_with_bundle.rb
@@ -3,13 +3,13 @@ shared_context "product is ordered as individual and within a bundle" do
   let(:parts) { (1..3).map { create(:variant) } }
 
   let(:bundle_variant) { order.variants.first }
-  let(:bundle) { bundle_variant.product }
+  let(:bundle) { bundle_variant }
 
   let(:common_product) { order.variants.last }
 
   before do
     expect(bundle_variant).to_not eql common_product
 
-    bundle.parts << [parts, common_product]
+    bundle.parts << parts
   end
 end

--- a/spree_product_assembly.gemspec
+++ b/spree_product_assembly.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency('spree_backend', '~> 2.2.0.beta')
+  s.add_dependency 'spree', '~> 2.2.0'
 
   s.add_development_dependency 'rspec-rails', '~> 2.14.0'
   s.add_development_dependency 'sqlite3'


### PR DESCRIPTION
* Move all parts logic to variant
* Fix all failing test
* Display variant's parts in product show view
* Allow to add parts to variants in backend
* And refactor some messy stuff

An assembly product could include product's parts plus variant's parts, or only product's parts.