### PR TITLE
Fix parts fontawesome icon.

### DIFF
--- a/app/views/spree/admin/shared/_product_assembly_product_tabs.html.erb
+++ b/app/views/spree/admin/shared/_product_assembly_product_tabs.html.erb
@@ -1,3 +1,3 @@
 <li<%= ' class="active"' if current == "Parts" %>>
-  <%= link_to_with_icon 'icon-sitemap', Spree.t(:parts), admin_product_parts_url(@product) %>
+  <%= link_to_with_icon 'sitemap', Spree.t(:parts), admin_product_parts_url(@product) %>
 </li>


### PR DESCRIPTION
Fontawesome changed its namespace a while back, and the icon doesn't work
because of it.
