### PR TITLE
2-2-stable should use Spree 2-2-stable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'spree', github: 'spree/spree', :branch => 'master'
+gem 'spree', github: 'spree/spree', :branch => '2-2-stable'
 
 gem 'pry-rails'
 gem 'pg'


### PR DESCRIPTION
This causes dependency issues when running tests.
