### PR TITLE
Require sass/rails

### DIFF
--- a/lib/spree_product_assembly.rb
+++ b/lib/spree_product_assembly.rb
@@ -1,3 +1,4 @@
 require 'spree_core'
 require 'spree_product_assembly/engine'
 require 'coffee_script'
+require 'sass/rails'


### PR DESCRIPTION
This fixes the long-standing issue where font-awesome couldn't be found. I am not joking.

See [my investigation here](https://github.com/bokmann/font-awesome-rails/issues/88#issuecomment-46927257).

I believe similar fixes applied to other extensions will fix the problem there too.
