### PR TITLE
Added model_class def to parts_controller

### DIFF
--- a/app/controllers/spree/admin/parts_controller.rb
+++ b/app/controllers/spree/admin/parts_controller.rb
@@ -42,4 +42,8 @@ class Spree::Admin::PartsController < Spree::Admin::BaseController
     def find_product
       @product = Spree::Product.find_by(slug: params[:product_id])
     end
+
+    def model_class
+      Spree::AssembliesPart
+    end
 end


### PR DESCRIPTION
As described in the [spree documentation](http://guides.spreecommerce.com/developer/security.html#custom-roles-in-the-admin-namespace), added the `model_class` definition (related to `AssembliesPart`) so an ability can be defined, such as:

``` ruby
class AbilityDecorator
  include CanCan::Ability
  def initialize(user)
    if user.respond_to?(:has_spree_role?) && user.has_spree_role?('some_role')
      ...
      can :manage, Spree::AssembliesPart
      ...
    end
  end
end

Spree::Ability.register_ability(AbilityDecorator)
```

Fixes #96
