### PR TITLE
Validate only additional parts necessary

### DIFF
--- a/app/models/spree/stock/availability_validator.rb
+++ b/app/models/spree/stock/availability_validator.rb
@@ -3,14 +3,17 @@ module Spree
     # Overridden from spree core to make it also check for assembly parts stock
     class AvailabilityValidator < ActiveModel::Validator
       def validate(line_item)
+        unit_count = line_item.inventory_units.size  
+        return if unit_count >= line_item.quantity
+        
         product = line_item.product
 
         valid = if product.assembly?
           line_item.parts.all? do |part|
-            Stock::Quantifier.new(part).can_supply?(line_item.count_of(part) * line_item.quantity)
+            Stock::Quantifier.new(part).can_supply?(line_item.count_of(part) * (line_item.quantity - unit_count))
           end
         else
-          Stock::Quantifier.new(line_item.variant).can_supply? line_item.quantity
+          Stock::Quantifier.new(line_item.variant).can_supply?(line_item.quantity - unit_count)
         end
 
         unless valid


### PR DESCRIPTION
The AvailabilityValidator seems to be validating for the entire quantity of the line_item instead of the quantity being added to the line_item (as spree's does). The proposed AvailabilityValidator change validates only the availability of additional parts needed to fulfill changes to the line_item's quantity.