### PR TITLE
Remove sleep, and switch to actual assertion within admin order edit test.

### DIFF
--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -16,33 +16,25 @@ describe "Orders", type: :feature, js: true do
   end
 
   it "allows admin to edit product bundle" do
-    change_orders_item_quantity_to 2
-
-    visit spree.edit_admin_order_path(order)
-
-    verify_3_parts_have_their_quantity_set_to 2
-  end
-
-  def change_orders_item_quantity_to(n)
     visit spree.edit_admin_order_path(order)
 
     within("table.product-bundles") do
       find(".edit-line-item").click
-      fill_in "quantity", with: n
+      fill_in "quantity", with: 2
       find(".save-line-item").click
     end
 
     wait_for_ajax
-  end
 
-  def verify_3_parts_have_their_quantity_set_to(n)
+    visit spree.edit_admin_order_path(order)
+
     within("table.stock-contents") do
       stock_quantities = all(".item-qty-show").map(&:text)
 
       expect(stock_quantities).to match [
-        "#{n} x backordered",
-        "#{n} x backordered",
-        "#{n} x backordered"
+        "2 x backordered",
+        "2 x backordered",
+        "2 x backordered"
       ]
     end
   end

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -28,7 +28,7 @@ describe "Orders", type: :feature, js: true do
 
     within("table.product-bundles") do
       find(".edit-line-item").click
-      fill_in "quantity", with: n.to_s
+      fill_in "quantity", with: n
       find(".save-line-item").click
     end
 

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -12,18 +12,38 @@ describe "Orders", type: :feature, js: true do
     bundle.parts << [parts]
     line_item.update_attributes!(quantity: 3)
     order.reload.create_proposed_shipments
-    order.finalize! 
+    order.finalize!
   end
 
   it "allows admin to edit product bundle" do
+    change_orders_item_quantity_to 2
+
+    visit spree.edit_admin_order_path(order)
+
+    verify_3_parts_have_their_quantity_set_to 2
+  end
+
+  def change_orders_item_quantity_to(n)
     visit spree.edit_admin_order_path(order)
 
     within("table.product-bundles") do
       find(".edit-line-item").click
-      fill_in "quantity", :with => "2"
+      fill_in "quantity", with: n.to_s
       find(".save-line-item").click
+    end
 
-      sleep(1) # avoid odd "cannot rollback - no transaction is active: rollback transaction"
+    wait_for_ajax
+  end
+
+  def verify_3_parts_have_their_quantity_set_to(n)
+    within("table.stock-contents") do
+      stock_quantities = all(".item-qty-show").map(&:text)
+
+      expect(stock_quantities).to match [
+        "#{n} x backordered",
+        "#{n} x backordered",
+        "#{n} x backordered"
+      ]
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,11 @@ require 'database_cleaner'
 require 'capybara/rspec'
 require 'capybara/rails'
 require 'capybara/poltergeist'
+
+Capybara.register_driver :poltergeist do |app|
+  Capybara::Poltergeist::Driver.new(app, timeout: 90)
+end
+
 Capybara.javascript_driver = :poltergeist
 
 Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each {|f| require f }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,6 +51,7 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
   end
 
+  config.include WaitForAjax, type: :feature
   config.include FactoryGirl::Syntax::Methods
   config.include Spree::TestingSupport::UrlHelpers
 end

--- a/spec/support/wait_for_ajax.rb
+++ b/spec/support/wait_for_ajax.rb
@@ -1,0 +1,11 @@
+module WaitForAjax
+  def wait_for_ajax
+    Timeout.timeout(Capybara.default_wait_time) do
+      loop until finished_all_ajax_requests?
+    end
+  end
+
+  def finished_all_ajax_requests?
+    page.evaluate_script('jQuery.active').zero?
+  end
+end


### PR DESCRIPTION
#### Why?
The admin order edit spec was randomly failing on Travis... 

#### What's changed?
This PR removes sleep in effort to deal with random failures, and changes the spec to assert that stock is in fact updated correctly.