### PR TITLE
Fixing issue with double tapped part creation. Adding "smart add"

### DIFF
--- a/app/models/spree/order_contents_decorator.rb
+++ b/app/models/spree/order_contents_decorator.rb
@@ -1,5 +1,26 @@
 module Spree
   OrderContents.class_eval do
+
+    def add_to_line_item(variant, quantity, options = {})
+      line_item = grab_line_item_by_variant(variant, false, options)
+
+      if line_item && part_variants_match?(line_item, variant, quantity, options)
+        line_item.quantity += quantity.to_i
+        line_item.currency = currency unless currency.nil?
+      else
+        opts = { currency: order.currency }.merge ActionController::Parameters.new(options).
+                                            permit(PermittedAttributes.line_item_attributes)
+        line_item = order.line_items.new(quantity: quantity,
+                                          variant: variant,
+                                          options: opts)
+      end
+
+      line_item.target_shipment = options[:shipment] if options.has_key? :shipment
+      line_item.save!
+
+      line_item
+    end
+
     def add_to_line_item_with_parts(variant, quantity, options = {})
       add_to_line_item_without_parts(variant, quantity, options).
         tap do |line_item|
@@ -10,17 +31,34 @@ module Spree
         )
       end
     end
+
     alias_method_chain :add_to_line_item, :parts
 
     private
 
+    def part_variants_match?(line_item, variant, quantity, options)
+      if line_item.parts.any? && options["selected_variants"]
+        selected_variant_ids = options["selected_variants"].values.map(&:to_i)
+        matched = part_variant_ids(line_item) & selected_variant_ids
+
+        matched == selected_variant_ids
+      else
+        true
+      end
+    end
+
+    def part_variant_ids(line_item)
+      line_item.part_line_items.map(&:variant_id)
+    end
+
     def populate_part_line_items(line_item, parts, selected_variants)
       parts.each do |part|
-        line_item.part_line_items.create!(
+        part_line_item = line_item.part_line_items.find_or_initialize_by(
           line_item: line_item,
-          variant_id: variant_id_for(part, selected_variants),
-          quantity: part.count
+          variant_id: variant_id_for(part, selected_variants)
         )
+
+        part_line_item.update_attributes!(quantity: part.count)
       end
     end
 

--- a/spec/features/adding_items_to_cart_spec.rb
+++ b/spec/features/adding_items_to_cart_spec.rb
@@ -194,7 +194,7 @@ RSpec.feature "Adding items to the cart", type: :feature do
       end
 
       context "and the user selects differing variants from the existing line item" do
-        specify "the cart contains incremented variants when listing bundle items" do
+        it "contains 2 line items of the same SKU with differing variants " do
           add_item_to_cart(size: "Large", color: "Red")
           add_item_to_cart(size: "XL", color: "Blue")
 
@@ -229,7 +229,7 @@ RSpec.feature "Adding items to the cart", type: :feature do
       end
 
       context "and the user selects the same variants as the existing line item" do
-        specify "the cart contains incremented variants when listing bundle items" do
+        it "contains 1 line item with incremented variants and quantities" do
           2.times { add_item_to_cart(size: "Large", color: "Red") }
 
           within "#cart-detail .line-item" do

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -2,22 +2,15 @@ require 'database_cleaner'
 
 RSpec.configure do |config|
   config.before(:suite) do
-    DatabaseCleaner.clean_with :truncation
+    DatabaseCleaner.clean_with(:truncation)
   end
 
-  config.before do
-    DatabaseCleaner.strategy = :transaction
-  end
-
-  config.before(:each, :js) do
-    DatabaseCleaner.strategy = :truncation
-  end
-
-  config.before do
+  config.before(:each) do |example|
+    DatabaseCleaner.strategy= example.metadata[:js] ? :truncation : :transaction
     DatabaseCleaner.start
   end
 
-  config.after do
+  config.after(:each) do
     DatabaseCleaner.clean
   end
 end

--- a/spree_product_assembly.gemspec
+++ b/spree_product_assembly.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sass-rails', '~> 4.0.0'
   s.add_development_dependency 'capybara', '~> 2.4'
   s.add_development_dependency 'poltergeist', '~> 1.6'
-  s.add_development_dependency 'database_cleaner', '~> 1.3'
+  s.add_development_dependency 'database_cleaner', '~> 1.4'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'pg'
 end


### PR DESCRIPTION
## What's new?
* Smart quantity increment/split for bundles when using product pages to "add" quantity to user selectable bundles
* Fix for #120 

## Smart increment/split rational.
With user selectable variants we run into a bit of weirdness...

**Example Setup**

**Product A:** 2 Variants - RED, BLUE
**Product B:** 2 Variants - Large, Medium
**Product C:** Bundles Product A & B.

**Current scenario:**

1. User adds C with RED, and Large.
2. User navigates back to product detail.
3. User adds C with BLUE, and Large.

**Cart shows:**
2 Product C with (2) Large, (1) BLUE, (1) RED

This doesn't really make sense from a bundling perspective, especially for decrements in quantity. What did you want to remove?

### After this PR:

##### Scenario 1:

1. User adds C with RED, and Large.
2. User navigates back to product detail.
3. User adds C with BLUE, and Large.

**Cart shows:**

(1) Product C with (1) RED, (1) Large
(1) Product C with (1) BLUE, (1) Large

##### Scenario 2:

1. User adds C with RED, and Large.
2. User navigates back to product detail.
3. User adds C with BLUE, and Medium.

**Cart shows:**

(1) Product C with (1) RED, (1) Large
(1) Product C with (1) BLUE, (1) Medium

##### Scenario 3:

1. User adds C with RED, and Large.
2. User navigates back to product detail.
3. User adds C with RED, and Large.

**Cart shows:**

(2) Product C with (2) RED, (2) Large