### PR TITLE
query param was double quoted

### DIFF
--- a/app/controllers/spree/admin/parts_controller.rb
+++ b/app/controllers/spree/admin/parts_controller.rb
@@ -19,7 +19,7 @@ class Spree::Admin::PartsController < Spree::Admin::BaseController
     if params[:q].blank?
       @available_products = []
     else
-      query = "%#{params[:q]}%"
+      query = "#{params[:q]}"
       @available_products = Spree::Product.search_can_be_part(query)
       @available_products.uniq!
     end


### PR DESCRIPTION
the q is quoted in product model, and thus not necessary here.