### PR TITLE
Changing config to load capybara after all other support files

### DIFF
--- a/spec/features/admin/parts_spec.rb
+++ b/spec/features/admin/parts_spec.rb
@@ -139,6 +139,8 @@ RSpec.feature "Managing parts for a product bundle", type: :feature, js: true do
       click_on "Parts"
       fill_in "searchtext", with: mug.name
       click_on "Search"
+
+      wait_for_ajax
       within("#search_hits") { click_on "Select" }
     end
 
@@ -147,6 +149,7 @@ RSpec.feature "Managing parts for a product bundle", type: :feature, js: true do
         fill_in "count", with: "5"
         find(".set_count_admin_product_part_link").click
 
+        wait_for_ajax
         expect(find_field('count').value).to eq "5"
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,4 +27,8 @@ RSpec.configure do |config|
   end
 end
 
-Dir[File.join(File.dirname(__FILE__), '/support/**/*.rb')].each { |file| require file }
+Dir[File.join(File.dirname(__FILE__), '/support/**/*.rb')].each do |file|
+  require file unless file.include? 'capybara'
+end
+
+require File.join(File.dirname(__FILE__), '/support/capybara.rb')

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -5,12 +5,14 @@ RSpec.configure do |config|
     DatabaseCleaner.clean_with(:truncation)
   end
 
-  config.before(:each) do |example|
-    DatabaseCleaner.strategy= example.metadata[:js] ? :truncation : :transaction
-    DatabaseCleaner.start
+  config.around(:each) do |example|
+    DatabaseCleaner.strategy = example.metadata[:js] ? :truncation : :transaction
+    DatabaseCleaner.cleaning do
+      example.run
+    end
   end
 
-  config.after(:each) do
+  config.after(:each) do |example|
     DatabaseCleaner.clean
   end
 end

--- a/spec/support/wait_for_ajax.rb
+++ b/spec/support/wait_for_ajax.rb
@@ -1,6 +1,6 @@
 module WaitForAjax
   def wait_for_ajax
-    Timeout.timeout(Capybara.default_wait_time) do
+    Timeout.timeout(Capybara.default_max_wait_time) do
       loop until finished_all_ajax_requests?
     end
   end


### PR DESCRIPTION
#### What's wrong?
There was a pesky spec that would randomly fail due to deadlocks in the DB: `spec/support/features/admin/parts_spec.rb:147`

#### What's new?
This PR fixes that issue! How?

* Changing before to around strategy
* Changing spec support requires to include capybara _after_ everything else.
* Adding a `wait_for_ajax` within the offending spec.

