### PR TITLE
Modify assemblies to be variants instead of product with few minor fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,7 @@
 source "https://rubygems.org"
 
-branch = '3-0-stable'
-gem 'spree', github: 'spree/spree', branch: branch
-gem 'spree_wombat', github: 'spree/spree_wombat', branch: branch
+gem 'spree', github: 'spree/spree', branch: 'master'
+gem 'spree_wombat', github: 'spree/spree_wombat', branch: 'master'
 
 gem 'pry-rails'
 

--- a/app/assets/javascripts/spree/backend/spree_product_assembly.js
+++ b/app/assets/javascripts/spree/backend/spree_product_assembly.js
@@ -1,2 +1,2 @@
 //= require spree/backend
-//= require spree_product_assembly/index
+//= require spree/backend/spree_product_assembly/index

--- a/app/assets/javascripts/spree/backend/spree_product_assembly.js
+++ b/app/assets/javascripts/spree/backend/spree_product_assembly.js
@@ -1,0 +1,2 @@
+//= require spree/backend
+//= require spree_product_assembly/index

--- a/app/assets/javascripts/spree/backend/spree_product_assembly/index.js.coffee
+++ b/app/assets/javascripts/spree/backend/spree_product_assembly/index.js.coffee
@@ -62,15 +62,17 @@ $(document).ready ->
     part.count = quantityField.val()
 
     if row.hasClass("with-variants")
-      selectedVariantOption = $('select option:selected', row)
-      part.variant_id = selectedVariantOption.val()
+      selectedVariantOption = $('select.part_selector option:selected', row)
+      part.part_id = selectedVariantOption.val()
 
       if selectedVariantOption.text() == Spree.translations.user_selectable
         part.variant_selection_deferred = "t"
-        part.variant_id = link.data("master-variant-id")
+        part.part_id = link.data("master-variant-id")
 
     else
-      part.variant_id = $('input[name="part[id]"]', row).val()
+      part.part_id = $('input[name="part[id]"]', row).val()
+
+    part.assembly_id = $('[name="part[assembly_id]"]', row).val()
 
     makePostRequest(link, {assemblies_part: part})
 

--- a/app/assets/javascripts/spree/backend/spree_product_assembly/index.js.coffee
+++ b/app/assets/javascripts/spree/backend/spree_product_assembly/index.js.coffee
@@ -22,7 +22,6 @@ $(document).ready ->
      success: (request) ->
        searchResults.html(request)
        searchResults.show()
-       $('select.select2').select2()
      type: 'POST'
      url: searchUrl
 

--- a/app/assets/javascripts/spree/backend/spree_product_assembly/index.js.coffee
+++ b/app/assets/javascripts/spree/backend/spree_product_assembly/index.js.coffee
@@ -22,6 +22,7 @@ $(document).ready ->
      success: (request) ->
        searchResults.html(request)
        searchResults.show()
+       $('select.select2').select2()
      type: 'POST'
      url: searchUrl
 

--- a/app/assets/javascripts/spree/frontend/products/show.js.erb
+++ b/app/assets/javascripts/spree/frontend/products/show.js.erb
@@ -1,0 +1,8 @@
+$(document).ready(function(){
+  $('.assemblies_variant').first().show();
+
+  $('[name="variant_id"]').on('click', function(){
+    $('.assemblies_variant').hide();
+    $('.assemblies_for_variant_' + $(this).val()).show();
+  });
+})

--- a/app/assets/javascripts/spree/frontend/spree_product_assembly.js
+++ b/app/assets/javascripts/spree/frontend/spree_product_assembly.js
@@ -1,1 +1,2 @@
 //= require spree/frontend
+//= require spree/frontend/products/show

--- a/app/controllers/spree/admin/parts_controller.rb
+++ b/app/controllers/spree/admin/parts_controller.rb
@@ -2,7 +2,7 @@ class Spree::Admin::PartsController < Spree::Admin::BaseController
   helper_method :product
 
   def index
-    @parts = product.assemblies_parts
+    @parts = product.assemblies_parts.includes(:assembly, :part)
   end
 
   def remove
@@ -52,7 +52,8 @@ class Spree::Admin::PartsController < Spree::Admin::BaseController
     def new_part_params
       params.require(:assemblies_part).permit(
         :count,
-        :variant_id,
+        :part_id,
+        :assembly_id,
         :variant_selection_deferred
       )
     end

--- a/app/helpers/spree/admin/parts_helper.rb
+++ b/app/helpers/spree/admin/parts_helper.rb
@@ -1,0 +1,9 @@
+module Spree
+  module Admin
+    module PartsHelper
+      def variant_including_master_options(variant)
+        variant.is_master? ? 'Master' : variant.options_text
+      end
+    end
+  end
+end

--- a/app/models/spree/assemblies_part.rb
+++ b/app/models/spree/assemblies_part.rb
@@ -1,6 +1,6 @@
 module Spree
   class AssembliesPart < ActiveRecord::Base
-    belongs_to :assembly, class_name: "Spree::Product",
+    belongs_to :assembly, class_name: "Spree::Variant",
                           foreign_key: "assembly_id",
                           touch: true
 

--- a/app/models/spree/assign_part_to_bundle_form.rb
+++ b/app/models/spree/assign_part_to_bundle_form.rb
@@ -20,23 +20,31 @@ module Spree
     private
 
     def attributes
-      part_options.reject {|k, v| k.to_sym == :variant_id}
+      part_options.reject {|k, v| k.to_sym == :part_id}
     end
 
     def given_id?
       part_options[:id].present?
     end
 
-    def product_id
-      product.id
+    def assembly_id
+      assembly.id
     end
 
     def part_id
-      variant.id
+      part.id
     end
 
-    def variant
-      Spree::Variant.find(part_options[:variant_id])
+    def assembly
+      Spree::Variant.find_by(id: part_options[:assembly_id])
+    end
+
+    def part
+      if part_options[:part_id]
+        Spree::Variant.find_by(id: part_options[:part_id])
+      else
+        product.master
+      end
     end
 
     def variant_selection_deferred?
@@ -54,7 +62,7 @@ module Spree
         else
           Spree::AssembliesPart.find_or_initialize_by(
             variant_selection_deferred: variant_selection_deferred?,
-            assembly_id: product_id,
+            assembly_id: assembly_id,
             part_id: part_id
           )
         end

--- a/app/models/spree/order_contents_decorator.rb
+++ b/app/models/spree/order_contents_decorator.rb
@@ -26,7 +26,7 @@ module Spree
         tap do |line_item|
         populate_part_line_items(
           line_item,
-          variant.product.assemblies_parts,
+          variant.parts_variants,
           options["selected_variants"]
         )
       end
@@ -64,7 +64,7 @@ module Spree
 
     def variant_id_for(part, selected_variants)
       if part.variant_selection_deferred?
-        selected_variants[part.id.to_s]
+        selected_variants[part.part.id.to_s]
       else
         part.part.id
       end

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -1,7 +1,9 @@
 Spree::Variant.class_eval do
-  has_and_belongs_to_many  :assemblies, :class_name => "Spree::Product",
-        :join_table => "spree_assemblies_parts",
-        :foreign_key => "part_id", :association_foreign_key => "assembly_id"
+  has_many :parts_variants, class_name: "Spree::AssembliesPart", foreign_key: "assembly_id"
+  has_many :assemblies_variants, class_name: "Spree::AssembliesPart", foreign_key: "part_id"
+
+  has_many :assemblies, through: :assemblies_variants, class_name: "Spree::Variant", dependent: :destroy
+  has_many :parts, through: :parts_variants, class_name: "Spree::Variant", dependent: :destroy
 
   def assemblies_for(products)
     assemblies.where(id: products)

--- a/app/views/spree/admin/orders/_stock_contents.html.erb
+++ b/app/views/spree/admin/orders/_stock_contents.html.erb
@@ -7,7 +7,7 @@
         <%= label_tag 'selected_shipping_rate_id', Spree.t(:shipping_method) %>
         <%= select_tag :selected_shipping_rate_id,
               options_for_select(shipment.shipping_rates.map {|sr| ["#{sr.name} #{sr.display_price}", sr.id] }, shipment.selected_shipping_rate_id),
-              {:class => 'fullwidth', :data => {'shipment-number' => shipment.number } } %>
+              {:class => 'select2 fullwidth', :data => {'shipment-number' => shipment.number } } %>
       </div>
     </td>
     <td class="actions">

--- a/app/views/spree/admin/orders/_stock_contents.html.erb
+++ b/app/views/spree/admin/orders/_stock_contents.html.erb
@@ -7,7 +7,7 @@
         <%= label_tag 'selected_shipping_rate_id', Spree.t(:shipping_method) %>
         <%= select_tag :selected_shipping_rate_id,
               options_for_select(shipment.shipping_rates.map {|sr| ["#{sr.name} #{sr.display_price}", sr.id] }, shipment.selected_shipping_rate_id),
-              {:class => 'select2 fullwidth', :data => {'shipment-number' => shipment.number } } %>
+              {:class => 'fullwidth', :data => {'shipment-number' => shipment.number } } %>
       </div>
     </td>
     <td class="actions">

--- a/app/views/spree/admin/parts/_parts_table.html.erb
+++ b/app/views/spree/admin/parts/_parts_table.html.erb
@@ -3,7 +3,8 @@
   	<tr>
   	  <th><%= Spree.t(:sku) %></th>
   		<th><%= Spree.t(:name) %></th>
-  		<th><%= Spree.t(:options) %></th>
+      <th><%= Spree.t(:options) %></th>
+      <th><%= Spree.t(:variant) %></th>
   		<th><%= Spree.t(:qty) %></th>
   	</tr>
   </thead>
@@ -13,6 +14,7 @@
         <td><%= part.sku %></td>
         <td><%= part.name %></td>
         <td><%= variant_options part %></td>
+        <td><%= variant_including_master_options part.assembly %></td>
         <td><%= text_field_tag :count, part.count, class: "form-control" %></td>
   	    <td class="actions">
           <%= image_tag "spinner.gif", :style => "display:none", :class => "spinner" %>

--- a/app/views/spree/admin/parts/available.html.erb
+++ b/app/views/spree/admin/parts/available.html.erb
@@ -4,6 +4,7 @@
     <tr>
       <th><%= Spree.t(:name) %></th>
       <th><%= Spree.t(:options) %></th>
+      <th><%= Spree.t(:variants) %></th>
       <th><%= Spree.t(:qty) %></th>
       <th></th>
     </tr>
@@ -19,13 +20,18 @@
             <%- opts = part.variants.map {|v| [variant_options(v), v.id] } %>
             <%= select_tag "part[id]",
               options_for_select(opts),
-              include_blank: Spree.t(:user_selectable)
+              include_blank: Spree.t(:user_selectable), class: 'part_selector'
             %>
           <% else %>
             <%= hidden_field_tag "part[id]", part.master.id %>
             <%= Spree.t(:no_variants) %>
           <% end %>
         </td>
+        <% unless product.has_variants? %>
+          <td><%= hidden_field_tag "part[assembly_id]", product.master.id, class: 'parts-assembly' %>Master</td>
+        <% else %>
+          <td><%= select_tag "part[assembly_id]", options_from_collection_for_select(product.variants, "id", "options_text") %></td>
+        <% end %>
         <td><%= text_field_tag "part[count]", 1 %></td>
         <td class="actions">
           <%= image_tag "spinner.gif", :style => "display:none", :class => "spinner" %>

--- a/app/views/spree/admin/parts/available.html.erb
+++ b/app/views/spree/admin/parts/available.html.erb
@@ -20,7 +20,7 @@
             <%- opts = part.variants.map {|v| [variant_options(v), v.id] } %>
             <%= select_tag "part[id]",
               options_for_select(opts),
-              include_blank: Spree.t(:user_selectable), class: 'part_selector select2'
+              include_blank: Spree.t(:user_selectable), class: 'part_selector'
             %>
           <% else %>
             <%= hidden_field_tag "part[id]", part.master.id %>
@@ -30,7 +30,7 @@
         <% unless product.has_variants? %>
           <td><%= hidden_field_tag "part[assembly_id]", product.master.id, class: 'parts-assembly' %>Master</td>
         <% else %>
-          <td><%= select_tag "part[assembly_id]", options_from_collection_for_select(product.variants, "id", "options_text"), class: 'select2' %></td>
+          <td><%= select_tag "part[assembly_id]", options_from_collection_for_select(product.variants, "id", "options_text") %></td>
         <% end %>
         <td><%= text_field_tag "part[count]", 1 %></td>
         <td class="actions">

--- a/app/views/spree/admin/parts/available.html.erb
+++ b/app/views/spree/admin/parts/available.html.erb
@@ -20,7 +20,7 @@
             <%- opts = part.variants.map {|v| [variant_options(v), v.id] } %>
             <%= select_tag "part[id]",
               options_for_select(opts),
-              include_blank: Spree.t(:user_selectable), class: 'part_selector'
+              include_blank: Spree.t(:user_selectable), class: 'part_selector select2'
             %>
           <% else %>
             <%= hidden_field_tag "part[id]", part.master.id %>
@@ -30,7 +30,7 @@
         <% unless product.has_variants? %>
           <td><%= hidden_field_tag "part[assembly_id]", product.master.id, class: 'parts-assembly' %>Master</td>
         <% else %>
-          <td><%= select_tag "part[assembly_id]", options_from_collection_for_select(product.variants, "id", "options_text") %></td>
+          <td><%= select_tag "part[assembly_id]", options_from_collection_for_select(product.variants, "id", "options_text"), class: 'select2' %></td>
         <% end %>
         <td><%= text_field_tag "part[count]", 1 %></td>
         <td class="actions">

--- a/app/views/spree/products/show/_parts.html.erb
+++ b/app/views/spree/products/show/_parts.html.erb
@@ -1,38 +1,40 @@
 <% if @product.assemblies_parts.any? %>
-<div class="columns col-md-12">
-  <h6><%= Spree.t(:parts_included) %></h6>
+  <div class="columns col-md-12">
+    <h6><%= Spree.t(:parts_included) %></h6>
 
-  <ul id="products" class="inline product-listing list-unstyled" data-hook>
-    <% @product.assemblies_parts.each do |part| %>
-      <%- variant = part.part %>
+    <% @product.variants_or_master.each do |variant| %>
+      <ul id="products" class="inline product-listing list-unstyled assemblies_variant assemblies_for_variant_<%= variant.id %>" data-hook style='display:none;'>
+        <% variant.parts_variants.includes(:part).each do |part_variant| %>
+          <%- part = part_variant.part %>
 
-      <li id="product_<%= variant.product.id %>" class="columns three <%= cycle("alpha", "secondary", "", "omega secondary") %>" data-hook="products_list_item" itemscope itemtype="http://schema.org/Product">
-        <div class="product-image">
-          <%= link_to small_image(variant.product, itemprop: "name"), variant.product %>
-        </div>
-        <%= link_to truncate(variant.product.name, length: 50), variant.product, class: 'info', itemprop: "name", title: variant.product.name %>
+          <li id="product_<%= part.product.id %>" class="columns three <%= cycle("alpha", "secondary", "", "omega secondary") %>" data-hook="products_list_item" itemscope itemtype="http://schema.org/Product">
+            <div class="product-image">
+              <%= link_to small_image(part.product, itemprop: "name"), part.product %>
+            </div>
+            <%= link_to truncate(part.product.name, length: 50), part.product, class: 'info', itemprop: "name", title: part.product.name %>
 
-        <%- if !variant.in_stock? && !part.variant_selection_deferred? %>
-          <%- if variant.is_backorderable? %>
-            <div class="on-backorder"><%= Spree.t(:backorderable) %></div>
-          <%- else %>
-            <div class="out-of-stock"><%= Spree.t(:out_of_stock) %></div>
-          <%- end %>
-        <%- end %>
+            <%- if !part.in_stock? && !part_variant.variant_selection_deferred? %>
+              <%- if part.is_backorderable? %>
+                <div class="on-backorder"><%= Spree.t(:backorderable) %></div>
+              <%- else %>
+                <div class="out-of-stock"><%= Spree.t(:out_of_stock) %></div>
+              <%- end %>
+            <%- end %>
 
-        <%- if part.variant_selection_deferred? %>
-          <div class="variant-selection-deferred">
-            <%- product = variant.product %>
-            <%= label_tag "options_selected_variants_#{part.id}", Spree.t(:variant) %>
+            <%- if part_variant.variant_selection_deferred? %>
+              <div class="variant-selection-deferred">
+                <%- product = part.product %>
+                <%= label_tag "options_selected_variants_#{part.id}", Spree.t(:variant) %>
 
-            <%- opts = product.variants.map { |v| [variant_options(v), v.id] } %>
-            <%- opts_disabled = product.variants.each_with_object([]) { |v, o| o << v.id if !v.in_stock? && !v.is_backorderable? } %>
+                <%- opts = product.variants.map { |v| [variant_options(v), v.id] } %>
+                <%- opts_disabled = product.variants.each_with_object([]) { |v, o| o << v.id if !v.in_stock? && !v.is_backorderable? } %>
 
-            <%= select_tag "options[selected_variants][#{part.id}]", options_for_select(opts, disabled: opts_disabled)%>
-          </div>
-        <%- end %>
-      </li>
+                <%= select_tag "options[selected_variants][#{part.id}]", options_for_select(opts, disabled: opts_disabled)%>
+              </div>
+            <%- end %>
+          </li>
+        <% end %>
+      </ul>
     <% end %>
-  </ul>
-</div>
+  </div>
 <% end %>

--- a/app/views/spree/products/show/_parts.html.erb
+++ b/app/views/spree/products/show/_parts.html.erb
@@ -1,8 +1,8 @@
 <% if @product.assemblies_parts.any? %>
-<div class="columns">
+<div class="columns col-md-12">
   <h6><%= Spree.t(:parts_included) %></h6>
 
-  <ul id="products" class="inline product-listing" data-hook>
+  <ul id="products" class="inline product-listing list-unstyled" data-hook>
     <% @product.assemblies_parts.each do |part| %>
       <%- variant = part.part %>
 

--- a/lib/generators/spree_product_assembly/install/install_generator.rb
+++ b/lib/generators/spree_product_assembly/install/install_generator.rb
@@ -9,6 +9,7 @@ module SpreeProductAssembly
 
       def add_javascripts
         append_file "vendor/assets/javascripts/spree/backend/all.js", "//= require spree/backend/spree_product_assembly\n"
+        append_file "vendor/assets/javascripts/spree/frontend/all.js", "//= require spree/frontend/spree_product_assembly\n"
       end
 
       def run_migrations

--- a/lib/spree_product_assembly/engine.rb
+++ b/lib/spree_product_assembly/engine.rb
@@ -16,6 +16,8 @@ module SpreeProductAssembly
       end
     end
 
+    config.assets.precompile += %w( spinner.gif )
+
     config.to_prepare &method(:activate).to_proc
   end
 end

--- a/lib/spree_product_assembly/engine.rb
+++ b/lib/spree_product_assembly/engine.rb
@@ -16,9 +16,7 @@ module SpreeProductAssembly
       end
     end
 
-    initializer 'spree.assets.precompile', group: :all do |app|
-      app.config.assets.precompile += %w( spinner.gif )
-    end
+    config.assets.precompile += %w( spinner.gif )
 
     config.to_prepare &method(:activate).to_proc
   end

--- a/lib/spree_product_assembly/engine.rb
+++ b/lib/spree_product_assembly/engine.rb
@@ -16,7 +16,9 @@ module SpreeProductAssembly
       end
     end
 
-    config.assets.precompile += %w( spinner.gif )
+    initializer 'spree.assets.precompile', group: :all do |app|
+      app.config.assets.precompile += %w( spinner.gif )
+    end
 
     config.to_prepare &method(:activate).to_proc
   end

--- a/spec/factories/assemblies_part_factory.rb
+++ b/spec/factories/assemblies_part_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :assemblies_part, class: 'Spree::AssembliesPart' do
-    assembly { build(:product) }
+    assembly { build(:variant) }
     part { build(:variant) }
     count 1
     variant_selection_deferred false

--- a/spec/features/adding_items_to_cart_spec.rb
+++ b/spec/features/adding_items_to_cart_spec.rb
@@ -11,8 +11,8 @@ RSpec.feature "Adding items to the cart", type: :feature do
                                           sku: "SHIRT",
                                           can_be_part: true)
 
-        add_part_to_bundle(bundle, keychain.master)
-        add_part_to_bundle(bundle, shirt.master)
+        add_part_to_bundle(bundle.master, keychain.master)
+        add_part_to_bundle(bundle.master, shirt.master)
 
         visit spree.product_path(bundle)
 
@@ -43,8 +43,8 @@ RSpec.feature "Adding items to the cart", type: :feature do
           option_values: ["Small"]
         )
 
-        add_part_to_bundle(bundle, keychain.master, count: 2)
-        add_part_to_bundle(bundle, shirts_by_size["small"])
+        add_part_to_bundle(bundle.master, keychain.master, count: 2)
+        add_part_to_bundle(bundle.master, shirts_by_size["small"])
 
         visit spree.product_path(bundle)
 
@@ -69,8 +69,8 @@ RSpec.feature "Adding items to the cart", type: :feature do
                                             sku: "SHIRT",
                                             can_be_part: true)
 
-          add_part_to_bundle(bundle, keychain.master, count: 2)
-          add_part_to_bundle(bundle, shirt.master)
+          add_part_to_bundle(bundle.master, keychain.master, count: 2)
+          add_part_to_bundle(bundle.master, shirt.master)
 
           visit spree.product_path(bundle)
 
@@ -102,8 +102,8 @@ RSpec.feature "Adding items to the cart", type: :feature do
           option_values: ["Small"]
         )
 
-        add_part_to_bundle(bundle, keychain.master)
-        add_part_to_bundle(bundle, shirts_by_size["small"])
+        add_part_to_bundle(bundle.master, keychain.master)
+        add_part_to_bundle(bundle.master, shirts_by_size["small"])
 
         visit spree.product_path(bundle)
 
@@ -118,7 +118,7 @@ RSpec.feature "Adding items to the cart", type: :feature do
       end
     end
 
-    context "when one of the bundle items has a user-selectable variant" do
+    context "when one of the bundle items has a user-selectable variant", js: true do
       scenario "the cart includes the variant when listing bundle items" do
         bundle = create(:product_in_stock, name: "Bundle", sku: "BUNDLE")
 
@@ -130,16 +130,17 @@ RSpec.feature "Adding items to the cart", type: :feature do
           name: "Shirt", option_type: "Size", option_values: ["Small", "Medium"]
         )
 
-        add_part_to_bundle(bundle, keychain.master, count: 1)
+        add_part_to_bundle(bundle.master, keychain.master, count: 1)
         add_part_to_bundle(
-          bundle,
+          bundle.master,
           shirt.master,
+          count: 1,
           variant_selection_deferred: true
         )
 
         visit spree.product_path(bundle)
 
-        select "Size: Medium", from: "Variant"
+        select 'Size: Medium', from: 'Variant'
 
         click_button "add-to-cart-button"
 
@@ -175,19 +176,19 @@ RSpec.feature "Adding items to the cart", type: :feature do
 
       before do
         add_part_to_bundle(
-          bundle,
+          bundle.master,
           keychain.master,
           count: 1
         )
 
         add_part_to_bundle(
-          bundle,
+          bundle.master,
           shirt.master,
           variant_selection_deferred: true
         )
 
         add_part_to_bundle(
-          bundle,
+          bundle.master,
           hat.master,
           variant_selection_deferred: true
         )
@@ -253,8 +254,8 @@ RSpec.feature "Adding items to the cart", type: :feature do
   def add_item_to_cart(args)
     visit spree.product_path(bundle)
 
-    select "Size: #{args[:size]}", from: "options_selected_variants_2"
-    select "Color: #{args[:color]}", from: "options_selected_variants_3"
+    select "Size: #{args[:size]}", from: "options_selected_variants_3"
+    select "Color: #{args[:color]}", from: "options_selected_variants_6"
     click_button "add-to-cart-button"
   end
 
@@ -298,13 +299,13 @@ RSpec.feature "Adding items to the cart", type: :feature do
     end
   end
 
-  def add_part_to_bundle(bundle, variant, options = {})
+  def add_part_to_bundle(bundle_master, variant, options = {})
     attributes = options.reverse_merge(
-      assembly_id: bundle.id,
+      assembly_id: bundle_master.id,
       part_id: variant.id,
     )
     create(:assemblies_part, attributes).tap do |_part|
-      bundle.reload
+      bundle_master.product.reload
     end
   end
 end

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Orders", type: :feature, js: true do
   given(:parts) { (1..3).map { create(:variant) } }
 
   background do
-    bundle.parts << [parts]
+    bundle.master.parts << [parts]
     line_item.update_attributes!(quantity: 3)
     order.reload.create_proposed_shipments
     order.finalize!

--- a/spec/features/admin/parts_spec.rb
+++ b/spec/features/admin/parts_spec.rb
@@ -123,7 +123,7 @@ RSpec.feature "Managing parts for a product bundle", type: :feature, js: true do
     fill_in "searchtext", with: mug.name
     click_on "Search"
 
-    within("#search_hits") { click_on "Select" }
+    within('#search_hits .actions') { click_on "Select" }
     expect(page).to have_content(mug.sku)
 
     within("#product_parts") do

--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Checkout", type: :feature do
 
   stub_authorization!
 
-  background { product.parts.push variant }
+  background { product.master.parts.push variant }
 
   shared_context "purchases product with part included" do
     background do
@@ -162,7 +162,7 @@ RSpec.feature "Checkout", type: :feature do
       visit spree.root_path
       click_link bundle.name
 
-      first_selectable = bundle.assemblies_parts.first.id
+      first_selectable = bundle.master.parts_variants.first.id
 
       within("#options_selected_variants_#{first_selectable}") do
         expect(page).to have_css("option[value='#{red.id}']")

--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -78,9 +78,9 @@ RSpec.feature "Checkout", type: :feature do
 
       bundle = create(:product, name: "Bundle")
 
-      create(:assemblies_part, assembly_id: bundle.id,
+      create(:assemblies_part, assembly_id: bundle.master.id,
                                part_id: rock.master.id)
-      create(:assemblies_part, assembly_id: bundle.id,
+      create(:assemblies_part, assembly_id: bundle.master.id,
                                part_id: stick.master.id)
       bundle.reload
 
@@ -102,9 +102,9 @@ RSpec.feature "Checkout", type: :feature do
 
       bundle = create(:product, name: "Bundle")
 
-      create(:assemblies_part, assembly_id: bundle.id,
+      create(:assemblies_part, assembly_id: bundle.master.id,
                                part_id: rock.master.id)
-      create(:assemblies_part, assembly_id: bundle.id,
+      create(:assemblies_part, assembly_id: bundle.master.id,
                                part_id: stick.master.id)
 
       bundle.reload
@@ -154,7 +154,7 @@ RSpec.feature "Checkout", type: :feature do
 
       bundle = create(:product, name: "Bundle")
 
-      create(:assemblies_part, assembly_id: bundle.id,
+      create(:assemblies_part, assembly_id: bundle.master.id,
                                part_id: shirt.master.id,
                                variant_selection_deferred: true)
       bundle.reload
@@ -162,7 +162,7 @@ RSpec.feature "Checkout", type: :feature do
       visit spree.root_path
       click_link bundle.name
 
-      first_selectable = bundle.master.parts_variants.first.id
+      first_selectable = bundle.master.parts_variants.first.part_id
 
       within("#options_selected_variants_#{first_selectable}") do
         expect(page).to have_css("option[value='#{red.id}']")
@@ -200,7 +200,7 @@ RSpec.feature "Checkout", type: :feature do
       bundle = create(:product, name: "Bundle")
 
       create(:assemblies_part,
-             assembly_id: bundle.id,
+             assembly_id: bundle.master.id,
              part_id: shirt.master.id,
              variant_selection_deferred: true)
       bundle.reload

--- a/spec/features/updating_items_in_cart_spec.rb
+++ b/spec/features/updating_items_in_cart_spec.rb
@@ -11,8 +11,8 @@ RSpec.feature "Updating items in the cart", type: :feature do
                                           sku: "SHIRT",
                                           can_be_part: true)
 
-        add_part_to_bundle(bundle, keychain.master)
-        add_part_to_bundle(bundle, shirt.master)
+        add_part_to_bundle(bundle.master, keychain.master)
+        add_part_to_bundle(bundle.master, shirt.master)
 
         visit spree.product_path(bundle)
 
@@ -48,8 +48,8 @@ RSpec.feature "Updating items in the cart", type: :feature do
           option_values: ["Small"]
         )
 
-        add_part_to_bundle(bundle, keychain.master, count: 2)
-        add_part_to_bundle(bundle, shirts_by_size["small"])
+        add_part_to_bundle(bundle.master, keychain.master, count: 2)
+        add_part_to_bundle(bundle.master, shirts_by_size["small"])
 
         visit spree.product_path(bundle)
 
@@ -85,8 +85,8 @@ RSpec.feature "Updating items in the cart", type: :feature do
           option_values: ["Small"]
         )
 
-        add_part_to_bundle(bundle, keychain.master)
-        add_part_to_bundle(bundle, shirts_by_size["small"])
+        add_part_to_bundle(bundle.master, keychain.master)
+        add_part_to_bundle(bundle.master, shirts_by_size["small"])
 
         visit spree.product_path(bundle)
 
@@ -107,7 +107,7 @@ RSpec.feature "Updating items in the cart", type: :feature do
       end
     end
 
-    context "when one of the bundle items has a user-selectable variant" do
+    context "when one of the bundle items has a user-selectable variant", js: true do
       scenario "the variant quantity is multiplied by the new bundle quantity" do
         bundle = create(:product_in_stock, name: "Bundle", sku: "BUNDLE")
 
@@ -122,9 +122,9 @@ RSpec.feature "Updating items in the cart", type: :feature do
           option_values: ["Small", "Medium"]
         )
 
-        add_part_to_bundle(bundle, keychain.master, count: 1)
+        add_part_to_bundle(bundle.master, keychain.master, count: 1)
         add_part_to_bundle(
-          bundle,
+          bundle.master,
           shirt.master,
           variant_selection_deferred: true
         )
@@ -185,13 +185,13 @@ RSpec.feature "Updating items in the cart", type: :feature do
     end
   end
 
-  def add_part_to_bundle(bundle, variant, options = {})
+  def add_part_to_bundle(bundle_master, variant, options = {})
     attributes = options.reverse_merge(
-      assembly_id: bundle.id,
+      assembly_id: bundle_master.id,
       part_id: variant.id,
     )
     create(:assemblies_part, attributes).tap do |_part|
-      bundle.reload
+      bundle_master.reload
     end
   end
 end

--- a/spec/models/spree/assemblies_part_spec.rb
+++ b/spec/models/spree/assemblies_part_spec.rb
@@ -4,7 +4,7 @@ module Spree
     let(:variant) { create(:variant) }
 
     before do
-      product.parts.push variant
+      product.master.parts.push variant
     end
 
     context "get" do

--- a/spec/models/spree/assign_part_to_bundle_form_spec.rb
+++ b/spec/models/spree/assign_part_to_bundle_form_spec.rb
@@ -37,7 +37,7 @@ module Spree
           bundle = create(:product)
           part = create(:product, can_be_part: true)
 
-          part_options = { count: 2, variant_id: part.id }
+          part_options = { count: 2, part_id: part.id, assembly_id: bundle.id }
 
           command = AssignPartToBundleForm.new(bundle, part_options)
 

--- a/spec/models/spree/inventory_unit_spec.rb
+++ b/spec/models/spree/inventory_unit_spec.rb
@@ -16,7 +16,7 @@ module Spree
       let(:parts) { (1..2).map { create(:variant) } }
 
       before do
-        product.parts << parts
+        product.master.parts << parts
         order.create_proposed_shipments
         order.finalize!
       end

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -9,7 +9,7 @@ module Spree
     context "bundle parts stock" do
       let(:parts) { (1..2).map { create(:variant) } }
 
-      before { product.parts << parts }
+      before { product.master.parts << parts }
 
       context "one of them not in stock" do
         before do
@@ -46,7 +46,7 @@ module Spree
       let(:parts) { (1..2).map { create(:variant) } }
 
       before do
-        product.parts << parts
+        product.master.parts << parts
         order.create_proposed_shipments
         order.finalize!
       end

--- a/spec/models/spree/order_contents_spec.rb
+++ b/spec/models/spree/order_contents_spec.rb
@@ -6,7 +6,7 @@ describe Spree::OrderContents, type: :model do
         assembly = create(:product)
         pieces = create_list(:product, 2)
         pieces.each do |piece|
-          create(:assemblies_part, assembly: assembly, part: piece.master)
+          create(:assemblies_part, assembly: assembly.master, part: piece.master)
         end
 
         contents = described_class.new(order)

--- a/spec/models/spree/order_contents_spec.rb
+++ b/spec/models/spree/order_contents_spec.rb
@@ -49,10 +49,10 @@ describe Spree::OrderContents, type: :model do
         create(:variant_in_stock, product: shirt, option_values: [red_option])
         create(:variant_in_stock, product: shirt, option_values: [blue_option])
 
-        create(:assemblies_part,
+        assembly_part_keychain = create(:assemblies_part,
                assembly_id: assembly.id,
                part_id: keychain.master.id)
-        create(:assemblies_part,
+        assembly_part_shirt = create(:assemblies_part,
                assembly_id: assembly.id,
                part_id: shirt.master.id,
                variant_selection_deferred: true)
@@ -62,7 +62,8 @@ describe Spree::OrderContents, type: :model do
 
         line_item = contents.add_to_line_item_with_parts(assembly.master, 1, {
           "selected_variants" => {
-            "#{assembly.assemblies_parts.last.id}" => "#{shirt.variants.last.id}"
+            "#{assembly_part_keychain.part_id}" => "#{keychain.master.id}",
+            "#{assembly_part_shirt.part_id}" => "#{shirt.variants.last.id}"
           }
         })
 

--- a/spec/models/spree/order_inventory_assembly_spec.rb
+++ b/spec/models/spree/order_inventory_assembly_spec.rb
@@ -280,7 +280,7 @@ module Spree
 
         product = create(:product_in_stock, product_properties)
 
-        assemblies_part_attributes = { assembly: bundle }.merge(part)
+        assemblies_part_attributes = { assembly: bundle.master }.merge(part)
 
         if part[:variant_selection_deferred]
           create(:variant_in_stock, product: product,

--- a/spec/models/spree/order_inventory_assembly_spec.rb
+++ b/spec/models/spree/order_inventory_assembly_spec.rb
@@ -297,7 +297,7 @@ module Spree
         if part[:variant_selection_deferred]
           selected_variants = {
             "selected_variants" => {
-              "#{bundle.assemblies_parts.last.id}" => "#{variants.last.id}"
+              "#{bundle.master.parts_variants.last.part_id}" => "#{variants.last.id}"
             }
           }
         end

--- a/spec/models/spree/order_inventory_spec.rb
+++ b/spec/models/spree/order_inventory_spec.rb
@@ -11,7 +11,7 @@ module Spree
 
       let(:bundle) { create(:product) }
 
-      before { bundle.parts.push [guitar, bass] }
+      before { bundle.master.parts.push [guitar, bass] }
 
       let!(:bundle_item) { contents.add(bundle.master, 5) }
       let!(:guitar_item) { contents.add(guitar, 3) }

--- a/spec/models/spree/order_inventory_spec.rb
+++ b/spec/models/spree/order_inventory_spec.rb
@@ -11,7 +11,7 @@ module Spree
 
       let(:bundle) { create(:product) }
 
-      before { bundle.master.parts.push [guitar, bass] }
+      before { bundle.master.parts.push([guitar, bass]); bundle.reload }
 
       let!(:bundle_item) { contents.add(bundle.master, 5) }
       let!(:guitar_item) { contents.add(guitar, 3) }

--- a/spec/models/spree/order_inventory_spec.rb
+++ b/spec/models/spree/order_inventory_spec.rb
@@ -11,7 +11,10 @@ module Spree
 
       let(:bundle) { create(:product) }
 
-      before { bundle.master.parts.push([guitar, bass]); bundle.reload }
+      before do
+        bundle.master.parts.push([guitar, bass])
+        bundle.reload
+      end
 
       let!(:bundle_item) { contents.add(bundle.master, 5) }
       let!(:guitar_item) { contents.add(guitar, 3) }

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -11,12 +11,12 @@ describe Spree::Product, type: :model do
       @part2 = create(:product, can_be_part: true)
 
       create(:assemblies_part,
-        assembly: @product,
+        assembly: @product.master,
         part: @part1.master,
         count: 1
       )
       create(:assemblies_part,
-        assembly: @product,
+        assembly: @product.master,
         part: @part2.master,
         count: 4
       )

--- a/spec/models/spree/stock/availability_validator_spec.rb
+++ b/spec/models/spree/stock/availability_validator_spec.rb
@@ -33,7 +33,7 @@ module Spree
         let(:product) { line_item.product }
         let(:variant) { line_item.variant }
         let(:parts) { (1..2).map { create(:variant) } }
-        before { product.parts << parts }
+        before { product.master.parts << parts }
 
         subject { described_class.new }
 

--- a/spec/models/spree/stock/coordinator_spec.rb
+++ b/spec/models/spree/stock/coordinator_spec.rb
@@ -32,7 +32,7 @@ module Spree
 
         let(:bundle_item_quantity) { order.find_line_item_by_variant(bundle_variant).quantity }
 
-        before { bundle.parts << parts }
+        before { bundle.master.parts << parts }
 
         specify do
           expected_units_on_package = order.line_items.to_a.sum(&:quantity) - bundle_item_quantity + (bundle.parts.count * bundle_item_quantity)

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -2,15 +2,17 @@ module Spree
   describe Variant, type: :model do
     context "filter assemblies" do
       let(:mug) { create(:product) }
+      let(:mug_master) { mug.master }
       let(:tshirt) { create(:product) }
+      let(:tshirt_master) { tshirt.master }
       let(:variant) { create(:variant) }
 
       context "variant has more than one assembly" do
-        before { variant.assemblies.push [mug, tshirt] }
+        before { variant.assemblies.push [mug_master, tshirt_master] }
 
         it "returns both products" do
-          expect(variant.assemblies_for([mug, tshirt])).to include mug
-          expect(variant.assemblies_for([mug, tshirt])).to include tshirt
+          expect(variant.assemblies_for([mug_master, tshirt_master])).to include mug_master
+          expect(variant.assemblies_for([mug_master, tshirt_master])).to include tshirt_master
         end
 
         it { expect(variant).to be_a_part }
@@ -18,7 +20,7 @@ module Spree
 
       context "variant no assembly" do
         it "returns both products" do
-          expect(variant.assemblies_for([mug, tshirt])).to be_empty
+          expect(variant.assemblies_for([mug_master, tshirt_master])).to be_empty
         end
       end
     end

--- a/spec/serializers/spree/wombat/assembly_shipment_serializer_spec.rb
+++ b/spec/serializers/spree/wombat/assembly_shipment_serializer_spec.rb
@@ -7,7 +7,7 @@ module Spree
       context "with bundle line item" do
         let(:bundle) { create(:variant) }
         let!(:parts) { (1..2).map { create(:variant) } }
-        let!(:bundle_parts) { bundle.product.parts << parts }
+        let!(:bundle_parts) { bundle.parts << parts }
         let!(:line_item) { order.contents.add(bundle, 1) }
         let!(:shipment) { order.create_proposed_shipments.first }
         let(:serialized_shipment) { JSON.parse(AssemblyShipmentSerializer.new(shipment, root: false).to_json) }

--- a/spec/support/shared_contexts/order_with_bundle.rb
+++ b/spec/support/shared_contexts/order_with_bundle.rb
@@ -8,6 +8,6 @@ shared_context "product is ordered as individual and within a bundle" do
   let(:common_product) { order.variants.last }
 
   before do
-    bundle.parts << [parts, common_product]
+    bundle.master.parts << [parts, common_product]
   end
 end

--- a/spree_product_assembly.gemspec
+++ b/spree_product_assembly.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_backend', '~> 3.0'
+  s.add_dependency 'spree_backend', '~> 3.1.0.beta'
 
-  s.add_development_dependency 'active_model_serializers', '0.9.0.alpha1'
+  s.add_development_dependency 'active_model_serializers', '~> 0.8.3'
   s.add_development_dependency 'capybara', '~> 2.4'
   s.add_development_dependency 'coffee-rails', '~> 4.0.0'
   s.add_development_dependency 'database_cleaner', '~> 1.4'
@@ -26,8 +26,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'launchy'
   s.add_development_dependency 'pg'
   s.add_development_dependency 'poltergeist', '~> 1.6'
-  s.add_development_dependency 'rspec-rails', '~> 3.3.0'
-  s.add_development_dependency 'sass-rails', '~> 4.0.0'
+  s.add_development_dependency 'rspec-rails', '~> 3.4.0'
+  s.add_development_dependency 'sass-rails', '~> 5.0.0'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
 end


### PR DESCRIPTION
This PR allows to add parts on variant level instead of just product level.

Please refer - https://github.com/spree-contrib/spree-product-assembly/issues/132