### PR TITLE
Add scope to show only products which are not assemblies

### DIFF
--- a/app/controllers/spree/admin/parts_controller.rb
+++ b/app/controllers/spree/admin/parts_controller.rb
@@ -20,7 +20,7 @@ class Spree::Admin::PartsController < Spree::Admin::BaseController
       @available_products = []
     else
       query = "%#{params[:q]}%"
-      @available_products = Spree::Product.search_can_be_part(query)
+      @available_products = Spree::Product.without_parts.search_can_be_part(query)
       @available_products.uniq!
     end
     respond_to do |format|

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -11,6 +11,8 @@ Spree::Product.class_eval do
     .limit(30)
   }
 
+  scope :without_parts, -> { eager_load(:assemblies_parts).where("spree_assemblies_parts.assembly_id IS NULL") }
+
   validate :assembly_cannot_be_part, if: :assembly?
 
   def variants_or_master


### PR DESCRIPTION
A scope in the product with name `without_parts` is added. As currently when available products are searched, it shows all the products including those which are assemblies.
An assembly product should only be able to add only non-assembly products.