### PR TITLE
Hide parts tab if product is can be part

### DIFF
--- a/app/views/spree/admin/shared/_product_assembly_product_tabs.html.erb
+++ b/app/views/spree/admin/shared/_product_assembly_product_tabs.html.erb
@@ -1,3 +1,3 @@
 <%= content_tag :li , class: ('active' if current == 'Parts') do %>
   <%= link_to_with_icon 'th', Spree.t(:parts), admin_product_parts_url(@product) %>
-<% end %>
+<% end unless @product.can_be_part? %>


### PR DESCRIPTION
When a product is marked `can_be_part` and then if admin goes to parts tab and add its parts.
After that whatever you update in product there will be a validation fail which is included by this gem [here](https://github.com/spree-contrib/spree-product-assembly/blob/master/app/models/spree/product_decorator.rb#L31).
Its a bug, should be handled by this way or some other way.