### PR TITLE
Add validation to not to add same assembly product as a part of that product

### DIFF
--- a/app/models/spree/assemblies_part.rb
+++ b/app/models/spree/assemblies_part.rb
@@ -6,6 +6,8 @@ module Spree
 
     belongs_to :part, class_name: "Spree::Variant", foreign_key: "part_id"
 
+    validates :part_id, numericality: { other_than: :assembly_id, message: Spree.t(:must_be_other_than_assembly) }
+
     delegate :name, :sku, to: :part
 
     after_create :set_master_unlimited_stock

--- a/app/models/spree/assign_part_to_bundle_form.rb
+++ b/app/models/spree/assign_part_to_bundle_form.rb
@@ -3,6 +3,7 @@ module Spree
     include ActiveModel::Validations
 
     validates :quantity, numericality: {greater_than: 0}
+    validates :part_id, numericality: { other_than: :assembly_id, message: Spree.t(:must_be_other_than_assembly) }
 
     attr_reader :product, :part_options
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,3 +12,4 @@ en:
     part_of_bundle: 'Part of bundle %{sku}'
     selected_quantity_not_available: Selected quantity not available
     user_selectable: User Selectable
+    must_be_other_than_assembly: must be other than Assembly.


### PR DESCRIPTION
Same product can be added as a part for that product if it is marked `can_be_part`. That should not happen as you should not be able to add same product as a part of that product.