### PR TITLE
Fix stock availability bug fixes #162

### DIFF
--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -57,7 +57,7 @@ module Spree
     end
 
     def quantity_without_part_line_items(quantity)
-      product.assemblies_parts.each_with_object({}) do |ap, hash|
+      variant.parts_variants.each_with_object({}) do |ap, hash|
         hash[ap.part] = ap.count * quantity
       end
     end


### PR DESCRIPTION
Fixes issue #162 

Use variant parts when checking stock availability to allow multi variant assemblies to work properly when inventory tracking is active.

Added specs to TDD existing issue and fix.