### PR TITLE
Keep the original computation of spree

### DIFF
--- a/app/models/spree/inventory_unit_decorator.rb
+++ b/app/models/spree/inventory_unit_decorator.rb
@@ -6,7 +6,7 @@ module Spree
         total_value = line_item.quantity_by_variant.map { |part, quantity| part.price * quantity }.sum
         variant.price / total_value
       else
-        1 / BigDecimal.new(line_item.quantity)
+        quantity / BigDecimal.new(line_item.quantity)
       end
     end
   end


### PR DESCRIPTION
If the product is not an assembly, keep spree's original computation. The error manifests when computing return item refunds for line items with quantity greater than 1.