### PR TITLE
fix Spree::CheckoutController error

### DIFF
--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -21,5 +21,5 @@ module Spree
   end
 end
 
-Spree::CheckoutController.prepend Spree::CheckoutControllerDecorator
+Spree::CheckoutController.prepend Spree::CheckoutControllerDecorator if defined? Spree::Frontend
 


### PR DESCRIPTION
 fix Spree::CheckoutController error when Spree::Frontend is not used.